### PR TITLE
chore(types): export the FontStyles type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export interface UnifontOptions {
   storage?: Storage
 }
 
-export type { ResolveFontOptions } from './types'
+export type { FontStyles, ResolveFontOptions } from './types'
 export interface Unifont {
   resolveFont: (fontFamily: string, options?: ResolveFontOptions, providers?: string[]) => Promise<{
     provider?: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,9 +10,11 @@ interface ProviderContext {
   }
 }
 
+export type FontStyles = 'normal' | 'italic' | 'oblique'
+
 export interface ResolveFontOptions {
   weights: string[]
-  styles: Array<'normal' | 'italic' | 'oblique'>
+  styles: FontStyles[]
   // TODO: improve support and support unicode range
   subsets: string[]
   fallbacks?: string[]


### PR DESCRIPTION
required when working with extending / abstracting unifont and need to expose similar values

resolves #29 

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
