### PR TITLE
feat: retry fetch on network error

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -2,9 +2,11 @@ interface Mini$FetchOptions extends RequestInit {
   baseURL?: string
   responseType?: 'json' | 'text'
   query?: Record<string, any>
+  retries?: number
+  retryDelay?: number
 }
 
-function mini$fetch<T = unknown>(url: string, options?: Mini$FetchOptions) {
+function mini$fetch<T = unknown>(url: string, options?: Mini$FetchOptions): Promise<T> {
   if (options?.baseURL) {
     url = options.baseURL + url
   }
@@ -12,8 +14,20 @@ function mini$fetch<T = unknown>(url: string, options?: Mini$FetchOptions) {
     const params = new URLSearchParams(options.query)
     url = `${url}?${params.toString()}`
   }
+
+  const retries = options?.retries ?? 3
+  const retryDelay = options?.retryDelay ?? 1000
+
   return fetch(url, options)
-    .then(r => options?.responseType === 'json' ? r.json() : r.text()) as Promise<T>
+    .then(r => options?.responseType === 'json' ? r.json() : r.text())
+    .catch((err) => {
+      if (retries <= 0) {
+        throw err
+      }
+      console.warn(`Could not fetch from \`${url}\'. Will retry in \`${retryDelay}ms\`. \`${retries}\` retries left.`)
+      return new Promise(resolve => setTimeout(resolve, retryDelay))
+        .then(() => mini$fetch(url, { ...options, retries: retries - 1 }))
+    }) as Promise<T>
 }
 
 export const $fetch = Object.assign(mini$fetch, {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -24,7 +24,7 @@ function mini$fetch<T = unknown>(url: string, options?: Mini$FetchOptions): Prom
       if (retries <= 0) {
         throw err
       }
-      console.warn(`Could not fetch from \`${url}\'. Will retry in \`${retryDelay}ms\`. \`${retries}\` retries left.`)
+      console.warn(`Could not fetch from \`${url}\`. Will retry in \`${retryDelay}ms\`. \`${retries}\` retries left.`)
       return new Promise(resolve => setTimeout(resolve, retryDelay))
         .then(() => mini$fetch(url, { ...options, retries: retries - 1 }))
     }) as Promise<T>

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -58,7 +58,7 @@ describe('unifont', () => {
     const unifont = await createUnifont([
       providers.google(),
     ])
-    const { fonts } = await unifont.resolveFont('Inter')
+    const { fonts } = await unifont.resolveFont('Poppins')
     expect(fonts).toMatchInlineSnapshot(`[]`)
     expect(console.warn).toHaveBeenCalledTimes(3)
     expect(console.warn).toHaveBeenNthCalledWith(1, 'Could not fetch from `https://fonts.google.com/metadata/fonts`. Will retry in `1000ms`. `3` retries left.')

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { createUnifont, defineFontProvider } from '../src'
+import { createUnifont, defineFontProvider, providers } from '../src'
 
 describe('unifont', () => {
   it('works with no providers', async () => {
@@ -47,5 +47,30 @@ describe('unifont', () => {
       expect.objectContaining({}),
     )
     error.mockRestore()
+  })
+
+  it('retries on network errors', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    globalThis.fetch = vi.fn(() =>
+      Promise.reject(new Error('Network Error')),
+    )
+    const unifont = await createUnifont([
+      providers.google(),
+    ])
+    const { fonts } = await unifont.resolveFont('Inter')
+    expect(fonts).toMatchInlineSnapshot(`[]`)
+    expect(console.warn).toHaveBeenCalledTimes(3)
+    expect(console.warn).toHaveBeenNthCalledWith(1, 'Could not fetch from `https://fonts.google.com/metadata/fonts`. Will retry in `1000ms`. `3` retries left.')
+    expect(console.warn).toHaveBeenNthCalledWith(2, 'Could not fetch from `https://fonts.google.com/metadata/fonts`. Will retry in `1000ms`. `2` retries left.')
+    expect(console.warn).toHaveBeenNthCalledWith(3, 'Could not fetch from `https://fonts.google.com/metadata/fonts`. Will retry in `1000ms`. `1` retries left.')
+    expect(console.error).toHaveBeenCalledWith(
+      'Could not initialize provider `google`. `unifont` will not be able to process fonts provided by this provider.',
+      expect.objectContaining({}),
+    )
+    warn.mockRestore()
+    error.mockRestore()
+    // @ts-expect-error globalThis.fetch is altered
+    globalThis.fetch.mockRestore()
   })
 })


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

@danielroe 
Supports retry fetch on network error as mentioned in nuxt/fonts#356. Failing the build should be implemented in Nuxt Fonts.