### PR TITLE
fix: preserve original URL for retry attempts

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -7,24 +7,25 @@ interface Mini$FetchOptions extends RequestInit {
 }
 
 function mini$fetch<T = unknown>(url: string, options?: Mini$FetchOptions): Promise<T> {
+  let finalURL = url
   if (options?.baseURL) {
-    url = options.baseURL + url
+    finalURL = options.baseURL + finalURL
   }
   if (options?.query) {
     const params = new URLSearchParams(options.query)
-    url = `${url}?${params.toString()}`
+    finalURL = `${finalURL}?${params.toString()}`
   }
 
   const retries = options?.retries ?? 3
   const retryDelay = options?.retryDelay ?? 1000
 
-  return fetch(url, options)
+  return fetch(finalURL, options)
     .then(r => options?.responseType === 'json' ? r.json() : r.text())
     .catch((err) => {
       if (retries <= 0) {
         throw err
       }
-      console.warn(`Could not fetch from \`${url}\`. Will retry in \`${retryDelay}ms\`. \`${retries}\` retries left.`)
+      console.warn(`Could not fetch from \`${finalURL}\`. Will retry in \`${retryDelay}ms\`. \`${retries}\` retries left.`)
       return new Promise(resolve => setTimeout(resolve, retryDelay))
         .then(() => mini$fetch(url, { ...options, retries: retries - 1 }))
     }) as Promise<T>


### PR DESCRIPTION
Ensure retry mechanism uses the unmodified original URL, preventing potential mutation during fetch and retry attempts.

- resolves #78 

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
