### PR TITLE
feat: return font file priority

### DIFF
--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -1,4 +1,4 @@
-import type { ResolveFontOptions } from '../types'
+import type { FontFaceData, ResolveFontOptions } from '../types'
 
 import { hash } from 'ohash'
 import { extractFontFaceData } from '../css/parse'
@@ -29,7 +29,7 @@ export default defineFontProvider<ProviderOption>('google', async (_options = {}
 
   const userAgents = {
     woff2: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36',
-    ttf: 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/534.54.16 (KHTML, like Gecko) Version/5.1.4 Safari/534.54.16',
+    woff: 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/534.54.16 (KHTML, like Gecko) Version/5.1.4 Safari/534.54.16',
   // eot: 'Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0)',
   // woff: 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:27.0) Gecko/20100101 Firefox/27.0',
   // svg: 'Mozilla/4.0 (iPad; CPU OS 4_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/4.1 Mobile/9A405 Safari/7534.48.3',
@@ -65,20 +65,28 @@ export default defineFontProvider<ProviderOption>('google', async (_options = {}
       resolvedAxes.push(axis)
     }
 
-    let css = ''
+    let priority = 0
+    const resolvedFontFaceData: FontFaceData[] = []
 
     for (const extension in userAgents) {
-      css += await $fetch<string>('/css2', {
+      const data = extractFontFaceData(await $fetch<string>('/css2', {
         baseURL: 'https://fonts.googleapis.com',
         headers: { 'user-agent': userAgents[extension as keyof typeof userAgents] },
         query: {
           family: `${family}:${resolvedAxes.join(',')}@${resolvedVariants.join(';')}`,
         },
+      }))
+      data.map((f) => {
+        f.meta ??= {}
+        f.meta.priority = priority
+        return f
       })
+      resolvedFontFaceData.push(...data)
+      priority++
     }
 
     // TODO: support subsets
-    return extractFontFaceData(css)
+    return resolvedFontFaceData
   }
 
   return {

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -29,7 +29,7 @@ export default defineFontProvider<ProviderOption>('google', async (_options = {}
 
   const userAgents = {
     woff2: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36',
-    woff: 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/534.54.16 (KHTML, like Gecko) Version/5.1.4 Safari/534.54.16',
+    ttf: 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/534.54.16 (KHTML, like Gecko) Version/5.1.4 Safari/534.54.16',
   // eot: 'Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0)',
   // woff: 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:27.0) Gecko/20100101 Firefox/27.0',
   // svg: 'Mozilla/4.0 (iPad; CPU OS 4_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/4.1 Mobile/9A405 Safari/7534.48.3',

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,11 @@ export interface FontFaceData {
   featureSettings?: string
   /** Allows low-level control over OpenType or TrueType font variations, by specifying the four letter axis names of the features to vary, along with their variation values. */
   variationSettings?: string
+  /** Metadata for the font face used by unifont */
+  meta?: {
+    /** The priority of the font face, usually used to indicate fallbacks. Smaller is more prioritized. */
+    priority?: number
+  }
 }
 
 export interface ResolveFontResult {

--- a/test/providers/google.test.ts
+++ b/test/providers/google.test.ts
@@ -55,14 +55,18 @@ describe('google', () => {
 
     const resolvedStyles = pickUniqueBy(fonts, fnt => fnt.style)
     const resolvedWeights = pickUniqueBy(fonts, fnt => String(fnt.weight))
+    const resolvedPriorities = pickUniqueBy(fonts, fnt => fnt.meta?.priority)
 
     const styles = ['oblique 0deg 15deg', 'normal'] as ResolveFontOptions['styles']
 
     // Variable wght and separate weights from 300 to 1000
     const weights = ['300,1000', ...([...Array.from({ length: 7 }).keys()].map(i => String(i * 100 + 300)))]
 
+    const priorities = [0, 1]
+
     expect(fonts).toHaveLength(11)
     expect(resolvedStyles).toMatchObject(styles)
     expect(resolvedWeights).toMatchObject(weights)
+    expect(resolvedPriorities).toMatchObject(priorities)
   })
 })


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

From nuxt/fonts#508.
This PR adds an additional `meta.priority` to `FontFaceData` to indicate fallback files.