### PR TITLE
fix!: only download variable font faces when necessary

### DIFF
--- a/src/providers/fontsource.ts
+++ b/src/providers/fontsource.ts
@@ -7,8 +7,7 @@ import { defineFontProvider, prepareWeights } from '../utils'
 const fontAPI = $fetch.create({ baseURL: 'https://api.fontsource.org/v1' })
 
 export default defineFontProvider('fontsource', async (_options, ctx) => {
-  const fonts = await ctx.storage.getItem('fontsource:meta.json', () =>
-    fontAPI<FontsourceFontMeta[]>('/fonts', { responseType: 'json' }))
+  const fonts = await ctx.storage.getItem('fontsource:meta.json', () => fontAPI<FontsourceFontMeta[]>('/fonts', { responseType: 'json' }))
   const familyMap = new Map<string, FontsourceFontMeta>()
 
   for (const meta of fonts) {
@@ -22,19 +21,12 @@ export default defineFontProvider('fontsource', async (_options, ctx) => {
       hasVariableWeights: font.variable,
       weights: font.weights.map(String),
     })
-    const styles = options.styles.filter(style =>
-      font.styles.includes(style),
-    )
-    const subsets = options.subsets
-      ? options.subsets.filter(subset => font.subsets.includes(subset))
-      : [font.defSubset]
+    const styles = options.styles.filter(style => font.styles.includes(style))
+    const subsets = options.subsets ? options.subsets.filter(subset => font.subsets.includes(subset)) : [font.defSubset]
     if (weights.length === 0 || styles.length === 0)
       return []
 
-    const fontDetail = await fontAPI<FontsourceFontDetail>(
-      `/fonts/${font.id}`,
-      { responseType: 'json' },
-    )
+    const fontDetail = await fontAPI<FontsourceFontDetail>(`/fonts/${font.id}`, { responseType: 'json' })
     const fontFaceData: FontFaceData[] = []
 
     for (const subset of subsets) {
@@ -42,38 +34,20 @@ export default defineFontProvider('fontsource', async (_options, ctx) => {
         for (const { weight, variable } of weights) {
           if (variable) {
             try {
-              const variableAxes = await ctx.storage.getItem(
-                `fontsource:${font.family}-axes.json`,
-                () =>
-                  fontAPI<FontsourceVariableFontDetail>(
-                    `/variable/${font.id}`,
-                    {
-                      responseType: 'json',
-                    },
-                  ),
-              )
+              const variableAxes = await ctx.storage.getItem(`fontsource:${font.family}-axes.json`, () => fontAPI<FontsourceVariableFontDetail>(`/variable/${font.id}`, { responseType: 'json' }))
               if (variableAxes && variableAxes.axes.wght) {
                 fontFaceData.push({
                   style,
-                  weight: [
-                    Number(variableAxes.axes.wght.min),
-                    Number(variableAxes.axes.wght.max),
-                  ],
+                  weight: [Number(variableAxes.axes.wght.min), Number(variableAxes.axes.wght.max)],
                   src: [
-                    {
-                      url: `https://cdn.jsdelivr.net/fontsource/fonts/${font.id}:vf@latest/${subset}-wght-${style}.woff2`,
-                      format: 'woff2',
-                    },
+                    { url: `https://cdn.jsdelivr.net/fontsource/fonts/${font.id}:vf@latest/${subset}-wght-${style}.woff2`, format: 'woff2' },
                   ],
-                  unicodeRange:
-                              fontDetail.unicodeRange[subset]?.split(','),
+                  unicodeRange: fontDetail.unicodeRange[subset]?.split(','),
                 })
               }
             }
             catch {
-              console.error(
-                `Could not download variable axes metadata for \`${font.family}\` from \`fontsource\`. \`unifont\` will not be able to inject variable axes for ${font.family}.`,
-              )
+              console.error(`Could not download variable axes metadata for \`${font.family}\` from \`fontsource\`. \`unifont\` will not be able to inject variable axes for ${font.family}.`)
             }
             continue
           }
@@ -82,10 +56,7 @@ export default defineFontProvider('fontsource', async (_options, ctx) => {
           fontFaceData.push({
             style,
             weight,
-            src: Object.entries(variantUrl).map(([format, url]) => ({
-              url,
-              format,
-            })),
+            src: Object.entries(variantUrl).map(([format, url]) => ({ url, format })),
             unicodeRange: fontDetail.unicodeRange[subset]?.split(','),
           })
         }
@@ -104,10 +75,7 @@ export default defineFontProvider('fontsource', async (_options, ctx) => {
         return
       }
 
-      const fonts = await ctx.storage.getItem(
-        `fontsource:${fontFamily}-${hash(options)}-data.json`,
-        () => getFontDetails(fontFamily, options),
-      )
+      const fonts = await ctx.storage.getItem(`fontsource:${fontFamily}-${hash(options)}-data.json`, () => getFontDetails(fontFamily, options))
       return { fonts }
     },
   }

--- a/src/providers/fontsource.ts
+++ b/src/providers/fontsource.ts
@@ -16,7 +16,7 @@ export default defineFontProvider('fontsource', async (_options, ctx) => {
 
   async function getFontDetails(family: string, options: ResolveFontOptions) {
     const font = familyMap.get(family)!
-    const weights = options.weights.filter(weight => font.weights.includes(Number(weight)))
+    const weights = options.weights.flatMap(weight => weight.includes('') ? weight.split(' ') : [weight]).filter(weight => font.weights.includes(Number(weight)))
     const styles = options.styles.filter(style => font.styles.includes(style))
     const subsets = options.subsets ? options.subsets.filter(subset => font.subsets.includes(subset)) : [font.defSubset]
     if (weights.length === 0 || styles.length === 0)
@@ -27,7 +27,7 @@ export default defineFontProvider('fontsource', async (_options, ctx) => {
 
     for (const subset of subsets) {
       for (const style of styles) {
-        if (font.variable) {
+        if (options.weights.some(weight => weight.includes(' ')) && font.variable) {
           try {
             const variableAxes = await ctx.storage.getItem(`fontsource:${font.family}-axes.json`, () => fontAPI<FontsourceVariableFontDetail>(`/variable/${font.id}`, { responseType: 'json' }))
             if (variableAxes && variableAxes.axes.wght) {

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -39,7 +39,7 @@ export default defineFontProvider<ProviderOption>('google', async (_options = {}
     const font = googleFonts.find(font => font.family === family)!
     const styles = [...new Set(options.styles.map(i => styleMap[i]))].sort()
 
-    const variableWeight = font.axes.find(a => a.tag === 'wght')
+    const variableWeight = options.weights.some(weight => weight.includes(' ')) && font.axes.find(a => a.tag === 'wght')
     const weights = variableWeight
       ? [`${variableWeight.min}..${variableWeight.max}`]
       : options.weights.filter(weight => weight in font.fonts)

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -3,7 +3,7 @@ import type { FontFaceData, ResolveFontOptions } from '../types'
 import { hash } from 'ohash'
 import { extractFontFaceData } from '../css/parse'
 import { $fetch } from '../fetch'
-import { defineFontProvider } from '../utils'
+import { defineFontProvider, prepareWeights } from '../utils'
 
 type VariableAxis = 'opsz' | 'slnt' | 'wdth' | (string & {})
 
@@ -46,11 +46,16 @@ export default defineFontProvider<ProviderOption>('google', async (_options = {}
     const font = googleFonts.find(font => font.family === family)!
     const styles = [...new Set(options.styles.map(i => styleMap[i]))].sort()
     const glyphs = _options.experimental?.glyphs?.[family]?.join('')
-
-    const variableWeight = options.weights.some(weight => weight.includes(' ')) && font.axes.find(a => a.tag === 'wght')
-    const weights = variableWeight
-      ? [`${variableWeight.min}..${variableWeight.max}`]
-      : options.weights.filter(weight => weight in font.fonts)
+    const weights = prepareWeights({
+      inputWeights: options.weights,
+      hasVariableWeights: font.axes.some(a => a.tag === 'wght'),
+      weights: Object.keys(font.fonts),
+    }).map(v => v.variable
+      ? ({
+          weight: v.weight.replace(' ', '..'),
+          variable: v.variable,
+        })
+      : v)
 
     if (weights.length === 0 || styles.length === 0)
       return []
@@ -60,7 +65,7 @@ export default defineFontProvider<ProviderOption>('google', async (_options = {}
 
     for (const axis of ['wght', 'ital', ...Object.keys(_options?.experimental?.variableAxis?.[family] ?? {})].sort(googleFlavoredSorting)) {
       const axisValue = ({
-        wght: weights,
+        wght: weights.map(v => v.weight),
         ital: styles,
       })[axis] ?? _options!.experimental!.variableAxis![family]![axis]!.map(v => Array.isArray(v) ? `${v[0]}..${v[1]}` : v)
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,3 +3,45 @@ import type { ProviderDefinition, ProviderFactory } from './types'
 export function defineFontProvider<T = unknown>(name: string, provider: ProviderDefinition<T>): ProviderFactory<T> {
   return ((options: T) => Object.assign(provider.bind(null, options || {} as T), { _name: name })) as ProviderFactory<T>
 }
+
+export function prepareWeights({
+  inputWeights,
+  weights,
+  hasVariableWeights,
+}: {
+  inputWeights: string[]
+  weights: string[]
+  hasVariableWeights: boolean
+}): { weight: string, variable: boolean }[] {
+  const collectedWeights: string[] = []
+
+  for (const weight of inputWeights) {
+    // The request weight is a range
+    if (weight.includes(' ')) {
+      if (hasVariableWeights) {
+        collectedWeights.push(weight)
+        continue
+      }
+      // As a fallback, request all weights in between
+      const [min, max] = weight.split(' ')
+      collectedWeights.push(
+        ...weights
+          .filter((_w) => {
+            const w = Number(_w)
+            return w >= Number(min) && w <= Number(max)
+          })
+          .map(w => String(w)),
+      )
+      continue
+    }
+    // The requested weight is a standard weight
+    if (weights.includes(weight)) {
+      collectedWeights.push(weight)
+    }
+  }
+
+  return [...new Set(collectedWeights)].map(weight => ({
+    weight,
+    variable: weight.includes(' '),
+  }))
+}

--- a/test/providers/fontsource.test.ts
+++ b/test/providers/fontsource.test.ts
@@ -15,27 +15,6 @@ describe('fontsource', () => {
           "src": [
             {
               "format": "woff2",
-              "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono:vf@latest/cyrillic-ext-wght-normal.woff2",
-            },
-          ],
-          "style": "normal",
-          "unicodeRange": [
-            "U+0460-052F",
-            "U+1C80-1C8A",
-            "U+20B4",
-            "U+2DE0-2DFF",
-            "U+A640-A69F",
-            "U+FE2E-FE2F",
-          ],
-          "weight": [
-            100,
-            700,
-          ],
-        },
-        {
-          "src": [
-            {
-              "format": "woff2",
               "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono@latest/cyrillic-ext-400-normal.woff2",
             },
             {
@@ -57,27 +36,6 @@ describe('fontsource', () => {
             "U+FE2E-FE2F",
           ],
           "weight": "400",
-        },
-        {
-          "src": [
-            {
-              "format": "woff2",
-              "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono:vf@latest/cyrillic-ext-wght-italic.woff2",
-            },
-          ],
-          "style": "italic",
-          "unicodeRange": [
-            "U+0460-052F",
-            "U+1C80-1C8A",
-            "U+20B4",
-            "U+2DE0-2DFF",
-            "U+A640-A69F",
-            "U+FE2E-FE2F",
-          ],
-          "weight": [
-            100,
-            700,
-          ],
         },
         {
           "src": [
@@ -109,26 +67,6 @@ describe('fontsource', () => {
           "src": [
             {
               "format": "woff2",
-              "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono:vf@latest/cyrillic-wght-normal.woff2",
-            },
-          ],
-          "style": "normal",
-          "unicodeRange": [
-            "U+0301",
-            "U+0400-045F",
-            "U+0490-0491",
-            "U+04B0-04B1",
-            "U+2116",
-          ],
-          "weight": [
-            100,
-            700,
-          ],
-        },
-        {
-          "src": [
-            {
-              "format": "woff2",
               "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono@latest/cyrillic-400-normal.woff2",
             },
             {
@@ -154,26 +92,6 @@ describe('fontsource', () => {
           "src": [
             {
               "format": "woff2",
-              "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono:vf@latest/cyrillic-wght-italic.woff2",
-            },
-          ],
-          "style": "italic",
-          "unicodeRange": [
-            "U+0301",
-            "U+0400-045F",
-            "U+0490-0491",
-            "U+04B0-04B1",
-            "U+2116",
-          ],
-          "weight": [
-            100,
-            700,
-          ],
-        },
-        {
-          "src": [
-            {
-              "format": "woff2",
               "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono@latest/cyrillic-400-italic.woff2",
             },
             {
@@ -194,27 +112,6 @@ describe('fontsource', () => {
             "U+2116",
           ],
           "weight": "400",
-        },
-        {
-          "src": [
-            {
-              "format": "woff2",
-              "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono:vf@latest/greek-wght-normal.woff2",
-            },
-          ],
-          "style": "normal",
-          "unicodeRange": [
-            "U+0370-0377",
-            "U+037A-037F",
-            "U+0384-038A",
-            "U+038C",
-            "U+038E-03A1",
-            "U+03A3-03FF",
-          ],
-          "weight": [
-            100,
-            700,
-          ],
         },
         {
           "src": [
@@ -246,27 +143,6 @@ describe('fontsource', () => {
           "src": [
             {
               "format": "woff2",
-              "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono:vf@latest/greek-wght-italic.woff2",
-            },
-          ],
-          "style": "italic",
-          "unicodeRange": [
-            "U+0370-0377",
-            "U+037A-037F",
-            "U+0384-038A",
-            "U+038C",
-            "U+038E-03A1",
-            "U+03A3-03FF",
-          ],
-          "weight": [
-            100,
-            700,
-          ],
-        },
-        {
-          "src": [
-            {
-              "format": "woff2",
               "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono@latest/greek-400-italic.woff2",
             },
             {
@@ -288,34 +164,6 @@ describe('fontsource', () => {
             "U+03A3-03FF",
           ],
           "weight": "400",
-        },
-        {
-          "src": [
-            {
-              "format": "woff2",
-              "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono:vf@latest/vietnamese-wght-normal.woff2",
-            },
-          ],
-          "style": "normal",
-          "unicodeRange": [
-            "U+0102-0103",
-            "U+0110-0111",
-            "U+0128-0129",
-            "U+0168-0169",
-            "U+01A0-01A1",
-            "U+01AF-01B0",
-            "U+0300-0301",
-            "U+0303-0304",
-            "U+0308-0309",
-            "U+0323",
-            "U+0329",
-            "U+1EA0-1EF9",
-            "U+20AB",
-          ],
-          "weight": [
-            100,
-            700,
-          ],
         },
         {
           "src": [
@@ -354,34 +202,6 @@ describe('fontsource', () => {
           "src": [
             {
               "format": "woff2",
-              "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono:vf@latest/vietnamese-wght-italic.woff2",
-            },
-          ],
-          "style": "italic",
-          "unicodeRange": [
-            "U+0102-0103",
-            "U+0110-0111",
-            "U+0128-0129",
-            "U+0168-0169",
-            "U+01A0-01A1",
-            "U+01AF-01B0",
-            "U+0300-0301",
-            "U+0303-0304",
-            "U+0308-0309",
-            "U+0323",
-            "U+0329",
-            "U+1EA0-1EF9",
-            "U+20AB",
-          ],
-          "weight": [
-            100,
-            700,
-          ],
-        },
-        {
-          "src": [
-            {
-              "format": "woff2",
               "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono@latest/vietnamese-400-italic.woff2",
             },
             {
@@ -410,38 +230,6 @@ describe('fontsource', () => {
             "U+20AB",
           ],
           "weight": "400",
-        },
-        {
-          "src": [
-            {
-              "format": "woff2",
-              "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono:vf@latest/latin-ext-wght-normal.woff2",
-            },
-          ],
-          "style": "normal",
-          "unicodeRange": [
-            "U+0100-02BA",
-            "U+02BD-02C5",
-            "U+02C7-02CC",
-            "U+02CE-02D7",
-            "U+02DD-02FF",
-            "U+0304",
-            "U+0308",
-            "U+0329",
-            "U+1D00-1DBF",
-            "U+1E00-1E9F",
-            "U+1EF2-1EFF",
-            "U+2020",
-            "U+20A0-20AB",
-            "U+20AD-20C0",
-            "U+2113",
-            "U+2C60-2C7F",
-            "U+A720-A7FF",
-          ],
-          "weight": [
-            100,
-            700,
-          ],
         },
         {
           "src": [
@@ -484,38 +272,6 @@ describe('fontsource', () => {
           "src": [
             {
               "format": "woff2",
-              "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono:vf@latest/latin-ext-wght-italic.woff2",
-            },
-          ],
-          "style": "italic",
-          "unicodeRange": [
-            "U+0100-02BA",
-            "U+02BD-02C5",
-            "U+02C7-02CC",
-            "U+02CE-02D7",
-            "U+02DD-02FF",
-            "U+0304",
-            "U+0308",
-            "U+0329",
-            "U+1D00-1DBF",
-            "U+1E00-1E9F",
-            "U+1EF2-1EFF",
-            "U+2020",
-            "U+20A0-20AB",
-            "U+20AD-20C0",
-            "U+2113",
-            "U+2C60-2C7F",
-            "U+A720-A7FF",
-          ],
-          "weight": [
-            100,
-            700,
-          ],
-        },
-        {
-          "src": [
-            {
-              "format": "woff2",
               "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono@latest/latin-ext-400-italic.woff2",
             },
             {
@@ -548,40 +304,6 @@ describe('fontsource', () => {
             "U+A720-A7FF",
           ],
           "weight": "400",
-        },
-        {
-          "src": [
-            {
-              "format": "woff2",
-              "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono:vf@latest/latin-wght-normal.woff2",
-            },
-          ],
-          "style": "normal",
-          "unicodeRange": [
-            "U+0000-00FF",
-            "U+0131",
-            "U+0152-0153",
-            "U+02BB-02BC",
-            "U+02C6",
-            "U+02DA",
-            "U+02DC",
-            "U+0304",
-            "U+0308",
-            "U+0329",
-            "U+2000-206F",
-            "U+20AC",
-            "U+2122",
-            "U+2191",
-            "U+2193",
-            "U+2212",
-            "U+2215",
-            "U+FEFF",
-            "U+FFFD",
-          ],
-          "weight": [
-            100,
-            700,
-          ],
         },
         {
           "src": [
@@ -621,40 +343,6 @@ describe('fontsource', () => {
             "U+FFFD",
           ],
           "weight": "400",
-        },
-        {
-          "src": [
-            {
-              "format": "woff2",
-              "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono:vf@latest/latin-wght-italic.woff2",
-            },
-          ],
-          "style": "italic",
-          "unicodeRange": [
-            "U+0000-00FF",
-            "U+0131",
-            "U+0152-0153",
-            "U+02BB-02BC",
-            "U+02C6",
-            "U+02DA",
-            "U+02DC",
-            "U+0304",
-            "U+0308",
-            "U+0329",
-            "U+2000-206F",
-            "U+20AC",
-            "U+2122",
-            "U+2191",
-            "U+2193",
-            "U+2212",
-            "U+2215",
-            "U+FEFF",
-            "U+FFFD",
-          ],
-          "weight": [
-            100,
-            700,
-          ],
         },
         {
           "src": [
@@ -708,40 +396,6 @@ describe('fontsource', () => {
           "src": [
             {
               "format": "woff2",
-              "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono:vf@latest/latin-wght-normal.woff2",
-            },
-          ],
-          "style": "normal",
-          "unicodeRange": [
-            "U+0000-00FF",
-            "U+0131",
-            "U+0152-0153",
-            "U+02BB-02BC",
-            "U+02C6",
-            "U+02DA",
-            "U+02DC",
-            "U+0304",
-            "U+0308",
-            "U+0329",
-            "U+2000-206F",
-            "U+20AC",
-            "U+2122",
-            "U+2191",
-            "U+2193",
-            "U+2212",
-            "U+2215",
-            "U+FEFF",
-            "U+FFFD",
-          ],
-          "weight": [
-            100,
-            700,
-          ],
-        },
-        {
-          "src": [
-            {
-              "format": "woff2",
               "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono@latest/latin-400-normal.woff2",
             },
             {
@@ -776,40 +430,6 @@ describe('fontsource', () => {
             "U+FFFD",
           ],
           "weight": "400",
-        },
-        {
-          "src": [
-            {
-              "format": "woff2",
-              "url": "https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono:vf@latest/latin-wght-italic.woff2",
-            },
-          ],
-          "style": "italic",
-          "unicodeRange": [
-            "U+0000-00FF",
-            "U+0131",
-            "U+0152-0153",
-            "U+02BB-02BC",
-            "U+02C6",
-            "U+02DA",
-            "U+02DC",
-            "U+0304",
-            "U+0308",
-            "U+0329",
-            "U+2000-206F",
-            "U+20AC",
-            "U+2122",
-            "U+2191",
-            "U+2193",
-            "U+2212",
-            "U+2215",
-            "U+FEFF",
-            "U+FFFD",
-          ],
-          "weight": [
-            100,
-            700,
-          ],
         },
         {
           "src": [
@@ -861,7 +481,7 @@ describe('fontsource', () => {
     })
 
     const unifont = await createUnifont([providers.fontsource()])
-    await unifont.resolveFont('Roboto Mono')
+    await unifont.resolveFont('Roboto Mono', { weights: ['400 700'] })
 
     expect(error).toHaveBeenCalledWith('Could not download variable axes metadata for `Roboto Mono` from `fontsource`. `unifont` will not be able to inject variable axes for Roboto Mono.')
 

--- a/test/providers/fontsource.test.ts
+++ b/test/providers/fontsource.test.ts
@@ -387,6 +387,12 @@ describe('fontsource', () => {
     `)
   })
 
+  it('supports variable fonts', async () => {
+    const unifont = await createUnifont([providers.fontsource()])
+    const { fonts } = await unifont.resolveFont('Roboto Mono', { weights: ['400 700'] })
+    expect(fonts.some(fnt => Array.isArray(fnt.weight))).toBe(true)
+  })
+
   it('handles default subsets', async () => {
     const unifont = await createUnifont([providers.fontsource()])
     const { fonts } = await unifont.resolveFont('Roboto Mono', { subsets: undefined })

--- a/test/providers/google.test.ts
+++ b/test/providers/google.test.ts
@@ -52,7 +52,7 @@ describe('google', () => {
       },
     })])
 
-    const { fonts } = await unifont.resolveFont('Recursive')
+    const { fonts } = await unifont.resolveFont('Recursive', { weights: ['300 1000'] })
 
     const resolvedStyles = pickUniqueBy(fonts, fnt => fnt.style)
     const resolvedWeights = pickUniqueBy(fonts, fnt => String(fnt.weight))
@@ -69,5 +69,13 @@ describe('google', () => {
     expect(resolvedStyles).toMatchObject(styles)
     expect(resolvedWeights).toMatchObject(weights)
     expect(resolvedPriorities).toMatchObject(priorities)
+  })
+
+  it('does not download variable fonts if a weight range is not specified', async () => {
+    const unifont = await createUnifont([providers.google()])
+
+    const { fonts } = await unifont.resolveFont('Roboto')
+
+    expect(fonts.map(fnt => Number(fnt.weight)).every(Boolean)).toBeTruthy()
   })
 })

--- a/test/providers/google.test.ts
+++ b/test/providers/google.test.ts
@@ -12,13 +12,11 @@ describe('google', () => {
 
   it('works', async () => {
     const unifont = await createUnifont([providers.google()])
-    expect(
-      await unifont.resolveFont('NonExistent Font').then(r => r.fonts),
-    ).toMatchInlineSnapshot(`[]`)
+    expect(await unifont.resolveFont('NonExistent Font').then(r => r.fonts)).toMatchInlineSnapshot(`[]`)
 
     const { fonts } = await unifont.resolveFont('Poppins')
 
-    expect(fonts).toHaveLength(6)
+    expect(fonts).toHaveLength(8)
   })
 
   it('filters fonts based on provided options', async () => {
@@ -35,7 +33,7 @@ describe('google', () => {
     const resolvedStyles = pickUniqueBy(fonts, fnt => fnt.style)
     const resolvedWeights = pickUniqueBy(fonts, fnt => String(fnt.weight))
 
-    expect(fonts).toHaveLength(3)
+    expect(fonts).toHaveLength(4)
     expect(resolvedStyles).toMatchObject(styles)
     expect(resolvedWeights).toMatchObject(weights)
   })

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { prepareWeights } from '../src/utils'
+
+describe('utils', () => {
+  describe('prepareWeights()', () => {
+    it('keeps variable weights if available', () => {
+      expect(prepareWeights({
+        inputWeights: ['400 900'],
+        hasVariableWeights: true,
+        weights: [],
+      })).toEqual([{ weight: '400 900', variable: true }])
+    })
+
+    it('returns nothing if a variable weight has no fallbacks', () => {
+      expect(prepareWeights({
+        inputWeights: ['300 700'],
+        hasVariableWeights: false,
+        weights: [],
+      })).toEqual([])
+    })
+
+    it('returns standard weights as fallbacks for a variable font if available', () => {
+      expect(
+        prepareWeights({
+          inputWeights: ['400 600'],
+          hasVariableWeights: false,
+          weights: ['300', '400', '500', '600', '700'],
+        }),
+      ).toEqual([
+        { weight: '400', variable: false },
+        { weight: '500', variable: false },
+        { weight: '600', variable: false },
+      ])
+    })
+
+    it('returns standard weights if available', () => {
+      expect(prepareWeights({
+        inputWeights: ['400', '500', '600'],
+        hasVariableWeights: false,
+        weights: ['300', '400'],
+      })).toEqual([{ weight: '400', variable: false }])
+    })
+
+    it('deduplicates weights', () => {
+      expect(
+        prepareWeights({
+          inputWeights: ['400 500', '300', '400', '500'],
+          hasVariableWeights: false,
+          weights: ['300', '400', '500'],
+        }),
+      ).toEqual([
+        { weight: '400', variable: false },
+        { weight: '500', variable: false },
+        { weight: '300', variable: false },
+      ])
+    })
+  })
+})


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

- Closes #108
- Prior to this PR, if a variable font was available for a given weight, it would be returned as well as the standard font files
- Now, a variable font is returned only if a weight range is provided