### PR TITLE
feat: add `meta.init` type to FontFaceData

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import type { InitializedProvider, Provider, ResolveFontOptions, ResolveFontResu
 import { createAsyncStorage, memoryStorage } from './cache'
 
 export * as providers from './providers'
-export type { FontFaceData, FontStyles, LocalFontSource, Provider, ProviderContext, ProviderDefinition, ProviderFactory, RemoteFontSource, ResolveFontOptions } from './types'
+export type { FontFaceData, FontFaceMeta, FontStyles, LocalFontSource, Provider, ProviderContext, ProviderDefinition, ProviderFactory, RemoteFontSource, ResolveFontOptions } from './types'
 export { defineFontProvider } from './utils'
 
 export interface UnifontOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,17 @@ export interface LocalFontSource {
   name: string
 }
 
+export interface FontFaceMeta {
+  /** The priority of the font face, usually used to indicate fallbacks. Smaller is more prioritized. */
+  priority?: number
+  /**
+   * A `RequestInit` object that should be used when fetching this font. This can be useful for
+   * adding authorization headers and other metadata required for a font request.
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/RequestInit
+   */
+  init?: RequestInit
+}
+
 // TODO: name
 export interface FontFaceData {
   src: Array<LocalFontSource | RemoteFontSource>
@@ -52,16 +63,7 @@ export interface FontFaceData {
   /** Allows low-level control over OpenType or TrueType font variations, by specifying the four letter axis names of the features to vary, along with their variation values. */
   variationSettings?: string
   /** Metadata for the font face used by unifont */
-  meta?: {
-    /** The priority of the font face, usually used to indicate fallbacks. Smaller is more prioritized. */
-    priority?: number
-    /**
-     * A `RequestInit` object that should be used when fetching this font. This can be useful for
-     * adding authorization headers and other metadata required for a font request.
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/RequestInit
-     */
-    init?: RequestInit
-  }
+  meta?: FontFaceMeta
 }
 
 export interface ResolveFontResult {

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,12 @@ export interface FontFaceData {
   meta?: {
     /** The priority of the font face, usually used to indicate fallbacks. Smaller is more prioritized. */
     priority?: number
+    /**
+     * A `RequestInit` object that should be used when fetching this font. This can be useful for
+     * adding authorization headers and other metadata required for a font request.
+     * @see https://developer.mozilla.org/en-US/docs/Web/API/RequestInit
+     */
+    init?: RequestInit
   }
 }
 

--- a/test/providers/custom.test.ts
+++ b/test/providers/custom.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { createUnifont, defineFontProvider } from '../../src'
+
+const init = { headers: { Authorization: 'Bearer password1234' } }
+/** Dummy custom provider for testing purposes. */
+const customProvider = defineFontProvider('custom', async () => {
+  return {
+    async resolveFont(family) {
+      return { fonts: [
+        {
+          src: [{ url: `https://example.com/${encodeURIComponent(family)}` }],
+          meta: { init },
+        },
+      ] }
+    },
+  }
+})
+
+describe('custom provider', () => {
+  it('works', async () => {
+    const unifont = await createUnifont([customProvider()])
+    expect(await unifont.resolveFont('Test Font').then(r => r.fonts)).toMatchInlineSnapshot(`
+      [
+        {
+          "meta": {
+            "init": {
+              "headers": {
+                "Authorization": "Bearer password1234",
+              },
+            },
+          },
+          "src": [
+            {
+              "url": "https://example.com/Test%20Font",
+            },
+          ],
+        },
+      ]
+    `)
+  })
+
+  it('includes an init object if set by the provider', async () => {
+    const unifont = await createUnifont([customProvider()])
+    expect(await unifont.resolveFont('Test Font').then(r => r.fonts.pop()?.meta?.init)).toMatchObject(init)
+  })
+})


### PR DESCRIPTION
Closes #143

This PR adds a new `init` field to the `meta` object providers can return with fonts. This allows users of `unifont` to request fonts with the required `fetch()` options (for example for authorization headers).

I added a small test suite for a barebones custom provider to assert that `init` objects set in a provider are surfaced as expected. `unifont` itself doesn’t use this metadata, it’s just a standard way of passing it from provider to unifont consumer.

The intention would be for downstream users like Nuxt Fonts and Astro to check for `meta.init` on returned fonts, and when present, request them something like this:

```js
const { fonts } = await unifont.resolveFont('Test Font');
for (const font of fonts) {
  for (const src of font.src) {
    const font = await fetch(src.url, font.meta?.init);
  }
}
```