### PR TITLE
fix: ensure unicodeRange is an array

### DIFF
--- a/src/css/parse.ts
+++ b/src/css/parse.ts
@@ -60,7 +60,7 @@ export function extractFontFaceData(css: string, family?: string): FontFaceData[
     for (const child of node.block?.children || []) {
       if (child.type === 'Declaration' && child.property in extractableKeyMap) {
         const value = extractCSSValue(child) as any
-        data[extractableKeyMap[child.property]!] = child.property === 'src' && !Array.isArray(value) ? [value] : value
+        data[extractableKeyMap[child.property]!] = ['src', 'unicode-range'].includes(child.property) && !Array.isArray(value) ? [value] : value
       }
     }
     if (!data.src) {

--- a/test/extract.test.ts
+++ b/test/extract.test.ts
@@ -119,4 +119,24 @@ describe('extract font face from CSS', () => {
       ]
     `)
   })
+
+  it('should always return unicodeRange as an array', () => {
+    expect(
+      extractFontFaceData(`
+@font-face {
+  src: url(https://fonts.gstatic.com/s/roboto/v47/KFOMCnqEu92Fr1ME7kSn66aGLdTylUAMQXC89YmC2DPNWubEbVmYiAr0klQmz24O0g.woff2) format("woff2");
+  unicode-range: U+1F00-1FFF;
+}`),
+    ).toEqual([
+      {
+        src: [
+          {
+            format: 'woff2',
+            url: 'https://fonts.gstatic.com/s/roboto/v47/KFOMCnqEu92Fr1ME7kSn66aGLdTylUAMQXC89YmC2DPNWubEbVmYiAr0klQmz24O0g.woff2',
+          },
+        ],
+        unicodeRange: ['U+1F00-1FFF'],
+      },
+    ])
+  })
 })


### PR DESCRIPTION
- Spotted in an Astro test
- Currently, the `unicodeRange` may be returned as a string but the type `FontFaceData` type specifies `string[]`