### PR TITLE
fix(adobe): refresh kit meta every five minutes

### DIFF
--- a/test/providers/adobe.test.ts
+++ b/test/providers/adobe.test.ts
@@ -122,7 +122,7 @@ describe('adobe', () => {
     expect(fonts.length).toBe(4)
   })
 
-  it('refetches kit metadata when font is not found in cache', async () => {
+  it('refreshes kit metadata when font is not found in cache', async () => {
     let apiCallCount = 0
 
     // Mock the API endpoint to return different kits on subsequent calls


### PR DESCRIPTION
Fixes #197 

Updates the Adobe provider:
- Updates the kit fetching to allow for bypassing the cache
- Re-fetches the kit if a font is missing

Update tests:
- Adds a test for the above
- Updates the `handles invalid JSON from adobe api` **Might need to be in a separate PR?**
  - Restores console.error by calling `vi.restoreAllMocks()` (Errors whilst I wrote the tests weren't working)
  - Update the mock fetch to return a promise (or `TypeError: fetch(...).then is not a function` is actually thrown, not the error that is expected)

