### PR TITLE
fix(googleicons): remove wrong and unused request

### DIFF
--- a/src/providers/googleicons.ts
+++ b/src/providers/googleicons.ts
@@ -40,15 +40,6 @@ export default defineFontProvider<ProviderOption>('googleicons', async (_options
 
     let css = ''
 
-    if (family.includes('Icons')) {
-      css += await $fetch<string>('/css2', {
-        baseURL: 'https://fonts.googleapis.com/icon',
-        query: {
-          family,
-        },
-      })
-    }
-
     for (const extension in userAgents) {
     // Legacy Material Icons
       if (family.includes('Icons')) {

--- a/test/providers/googleicons.test.ts
+++ b/test/providers/googleicons.test.ts
@@ -353,6 +353,10 @@ describe('googleicons', () => {
         {
           "src": [
             {
+              "format": "woff2",
+              "url": "https://fonts.gstatic.com/font",
+            },
+            {
               "format": "woff",
               "url": "https://fonts.gstatic.com/font",
             },


### PR DESCRIPTION
The request to `https://fonts.googleapis.com/icon/css2` is not used and returns 404. The 404 html also interferes with the CSS parser that it cannot correctly parse the woff2 file.