### PR TITLE
feat: include `subset` to `FontFaceMeta`

### DIFF
--- a/src/providers/fontsource.ts
+++ b/src/providers/fontsource.ts
@@ -43,6 +43,7 @@ export default defineFontProvider('fontsource', async (_options, ctx) => {
                     { url: `https://cdn.jsdelivr.net/fontsource/fonts/${font.id}:vf@latest/${subset}-wght-${style}.woff2`, format: 'woff2' },
                   ],
                   unicodeRange: fontDetail.unicodeRange[subset]?.split(','),
+                  meta: { subset },
                 })
               }
             }
@@ -58,6 +59,7 @@ export default defineFontProvider('fontsource', async (_options, ctx) => {
             weight,
             src: Object.entries(variantUrl).map(([format, url]) => ({ url, format })),
             unicodeRange: fontDetail.unicodeRange[subset]?.split(','),
+            meta: { subset },
           })
         }
       }

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -132,6 +132,9 @@ export default defineFontProvider<ProviderOption>('google', async (_options = {}
         data.map((f) => {
           f.meta ??= {}
           f.meta.priority = priority
+          if (group.subset) {
+            f.meta.subset = group.subset
+          }
           return f
         })
         resolvedFontFaceData.push(...data)

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,10 @@ export interface FontFaceMeta {
   /** The priority of the font face, usually used to indicate fallbacks. Smaller is more prioritized. */
   priority?: number
   /**
+   * The subset name of the font face. Many fonts provides font subsets such as latin, latin-ext, cyrillic, etc.
+   */
+  subset?: string
+  /**
    * A `RequestInit` object that should be used when fetching this font. This can be useful for
    * adding authorization headers and other metadata required for a font request.
    * @see https://developer.mozilla.org/en-US/docs/Web/API/RequestInit

--- a/test/providers/fontsource.test.ts
+++ b/test/providers/fontsource.test.ts
@@ -18,6 +18,9 @@ describe('fontsource', () => {
     expect(fonts).toMatchInlineSnapshot(`
       [
         {
+          "meta": {
+            "subset": "cyrillic-ext",
+          },
           "src": [
             {
               "format": "woff2",
@@ -44,6 +47,9 @@ describe('fontsource', () => {
           "weight": "400",
         },
         {
+          "meta": {
+            "subset": "cyrillic-ext",
+          },
           "src": [
             {
               "format": "woff2",
@@ -70,6 +76,9 @@ describe('fontsource', () => {
           "weight": "400",
         },
         {
+          "meta": {
+            "subset": "cyrillic",
+          },
           "src": [
             {
               "format": "woff2",
@@ -95,6 +104,9 @@ describe('fontsource', () => {
           "weight": "400",
         },
         {
+          "meta": {
+            "subset": "cyrillic",
+          },
           "src": [
             {
               "format": "woff2",
@@ -120,6 +132,9 @@ describe('fontsource', () => {
           "weight": "400",
         },
         {
+          "meta": {
+            "subset": "greek",
+          },
           "src": [
             {
               "format": "woff2",
@@ -146,6 +161,9 @@ describe('fontsource', () => {
           "weight": "400",
         },
         {
+          "meta": {
+            "subset": "greek",
+          },
           "src": [
             {
               "format": "woff2",
@@ -172,6 +190,9 @@ describe('fontsource', () => {
           "weight": "400",
         },
         {
+          "meta": {
+            "subset": "vietnamese",
+          },
           "src": [
             {
               "format": "woff2",
@@ -205,6 +226,9 @@ describe('fontsource', () => {
           "weight": "400",
         },
         {
+          "meta": {
+            "subset": "vietnamese",
+          },
           "src": [
             {
               "format": "woff2",
@@ -238,6 +262,9 @@ describe('fontsource', () => {
           "weight": "400",
         },
         {
+          "meta": {
+            "subset": "latin-ext",
+          },
           "src": [
             {
               "format": "woff2",
@@ -275,6 +302,9 @@ describe('fontsource', () => {
           "weight": "400",
         },
         {
+          "meta": {
+            "subset": "latin-ext",
+          },
           "src": [
             {
               "format": "woff2",
@@ -312,6 +342,9 @@ describe('fontsource', () => {
           "weight": "400",
         },
         {
+          "meta": {
+            "subset": "latin",
+          },
           "src": [
             {
               "format": "woff2",
@@ -351,6 +384,9 @@ describe('fontsource', () => {
           "weight": "400",
         },
         {
+          "meta": {
+            "subset": "latin",
+          },
           "src": [
             {
               "format": "woff2",
@@ -405,6 +441,9 @@ describe('fontsource', () => {
     expect(fonts).toMatchInlineSnapshot(`
       [
         {
+          "meta": {
+            "subset": "latin",
+          },
           "src": [
             {
               "format": "woff2",
@@ -444,6 +483,9 @@ describe('fontsource', () => {
           "weight": "400",
         },
         {
+          "meta": {
+            "subset": "latin",
+          },
           "src": [
             {
               "format": "woff2",

--- a/test/providers/google.test.ts
+++ b/test/providers/google.test.ts
@@ -18,6 +18,12 @@ describe('google', () => {
     const { fonts } = await unifont.resolveFont('Poppins')
 
     expect(fonts).toHaveLength(6)
+    expect(fonts[0]?.meta).toMatchInlineSnapshot(`
+      {
+        "priority": 0,
+        "subset": "latin-ext",
+      }
+    `)
   })
 
   it('filters fonts based on provided options', async () => {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

- Related https://github.com/unjs/fontaine/issues/649

This PR exposes `meta.subset` for supported providers (currently google and fontsource). This is required to allow fontless to select preload fonts based on language such as latin, latin-etc, etc.