### PR TITLE
feat: support `inferFontWeights` on google provider

### DIFF
--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -23,6 +23,12 @@ interface ProviderOption {
     glyphs?: {
       [fontFamily: string]: string[]
     }
+    /**
+     * Experimental: Inferring variable weight ranges for fonts that support variable weights but do not explicitly declare the `wght` axis.
+     */
+    inferVaraibleWeights?: boolean | {
+      [fontFamily: string]: boolean
+    }
   }
 }
 
@@ -78,9 +84,16 @@ export default defineFontProvider<ProviderOption>('google', async (_options = {}
     const font = googleFonts.find(font => font.family === family)!
     const styles = [...new Set(options.styles.map(i => styleMap[i]))].sort()
     const glyphs = _options.experimental?.glyphs?.[family]?.join('')
+    const weightAxis = font.axes.find(a => a.tag === 'wght')
+    const inferVariableWeights = typeof _options.experimental?.inferVaraibleWeights === 'object'
+      ? _options.experimental?.inferVaraibleWeights?.[family]
+      : _options.experimental?.inferVaraibleWeights
+    if (weightAxis && inferVariableWeights) {
+      options.weights = [`${weightAxis.min} ${weightAxis.max}`]
+    }
     const weights = prepareWeights({
       inputWeights: options.weights,
-      hasVariableWeights: font.axes.some(a => a.tag === 'wght'),
+      hasVariableWeights: !!weightAxis,
       weights: Object.keys(font.fonts),
     }).map(v => v.variable
       ? ({

--- a/test/providers/google.test.ts
+++ b/test/providers/google.test.ts
@@ -217,21 +217,28 @@ body {
   })
 
   it('inferVariableWeights', async () => {
-    const unifont = await createUnifont([providers.google({
-      experimental: {
-        inferVaraibleWeights: true,
-      },
-    })])
-    const { fonts } = await unifont.resolveFont('Inter', {
-      styles: ['normal'],
-    })
-    expect(fonts.find(f => f.meta?.priority === 0)?.weight).toMatchInlineSnapshot(`
-      [
-        100,
-        900,
-      ]
-    `)
-    // priority=1 doesn't return variable font
-    expect(fonts.find(f => f.meta?.priority === 1)?.weight).toMatchInlineSnapshot(`100`)
+    const testProviders = [
+      providers.google({
+        experimental: {
+          inferVaraibleWeights: true,
+        },
+      }),
+      providers.google({
+        experimental: {
+          inferVaraibleWeights: {
+            Inter: true,
+          },
+        },
+      }),
+    ]
+    for (const provider of testProviders) {
+      const unifont = await createUnifont([provider])
+      const { fonts } = await unifont.resolveFont('Inter', {
+        styles: ['normal'],
+      })
+      // priority=1 doesn't return variable font
+      expect(fonts.find(f => f.meta?.priority === 0)?.weight).toEqual([100, 900])
+      expect(fonts.find(f => f.meta?.priority === 1)?.weight).toEqual(100)
+    }
   })
 })

--- a/test/providers/google.test.ts
+++ b/test/providers/google.test.ts
@@ -215,4 +215,23 @@ body {
     })
     expect(fonts.length).toBe(18)
   })
+
+  it('inferVariableWeights', async () => {
+    const unifont = await createUnifont([providers.google({
+      experimental: {
+        inferVaraibleWeights: true,
+      },
+    })])
+    const { fonts } = await unifont.resolveFont('Inter', {
+      styles: ['normal'],
+    })
+    expect(fonts.find(f => f.meta?.priority === 0)?.weight).toMatchInlineSnapshot(`
+      [
+        100,
+        900,
+      ]
+    `)
+    // priority=1 doesn't return variable font
+    expect(fonts.find(f => f.meta?.priority === 1)?.weight).toMatchInlineSnapshot(`100`)
+  })
 })


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

- Related https://github.com/unjs/fontaine/issues/658

This PR adds google provider option `experimental.inferVariableWeights` to automatically configure full range of variable weights.