### PR TITLE
feat: add `excludeFallbackFormats` to google provider

### DIFF
--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -23,6 +23,10 @@ interface ProviderOption {
     glyphs?: {
       [fontFamily: string]: string[]
     }
+    /**
+     * Experimental: exclude fallback font format for old browsers without woff2 support
+     */
+    excludeFallbackFormats?: (fontFamily: string) => boolean
   }
 }
 
@@ -113,7 +117,12 @@ export default defineFontProvider<ProviderOption>('google', async (_options = {}
     let priority = 0
     const resolvedFontFaceData: FontFaceData[] = []
 
-    for (const extension in userAgents) {
+    let formats = Object.keys(userAgents)
+    if (_options.experimental?.excludeFallbackFormats?.(family)) {
+      formats = formats.slice(0, 1) // keep only woff2
+    }
+
+    for (const extension of formats) {
       const rawCss = await $fetch<string>('/css2', {
         baseURL: 'https://fonts.googleapis.com',
         headers: {

--- a/test/providers/google.test.ts
+++ b/test/providers/google.test.ts
@@ -215,4 +215,22 @@ body {
     })
     expect(fonts.length).toBe(18)
   })
+
+  it('experimental.includeFallbackFormat', async () => {
+    const unifont = await createUnifont([
+      providers.google({
+        experimental: {
+          excludeFallbackFormats: (fontFamily: string) => fontFamily === 'Poppins',
+        },
+      }),
+    ])
+    {
+      const { fonts } = await unifont.resolveFont('Poppins', {})
+      expect(fonts.filter(f => f.src.some(s => 'format' in s && s.format !== 'woff2'))).toEqual([])
+    }
+    {
+      const { fonts } = await unifont.resolveFont('Geist', {})
+      expect(fonts.filter(f => f.src.some(s => 'format' in s && s.format !== 'woff2'))).not.toEqual([])
+    }
+  })
 })


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

See https://github.com/unjs/fontaine/issues/659 and https://github.com/unjs/fontaine/pull/660 for more context. Including fallback font format for old browser is not a good default experience for fontless.

This adds an option to filter them out on unifont side.