### PR TITLE
chore: extract unifont

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,7 @@
 export * as providers from './providers'
-export type {
-  FontFaceData,
-  FontFaceMeta,
-  FontStyles,
-  LocalFontSource,
-  Provider,
-  ProviderContext,
-  ProviderDefinition,
-  ProviderFactory,
-  RemoteFontSource,
-  ResolveFontOptions,
-} from './types'
-export {
-  createUnifont,
-  defaultResolveOptions,
-} from './unifont'
-export type {
-  Unifont,
-  UnifontOptions,
-} from './unifont'
+
+export type { FontFaceData, FontFaceMeta, FontStyles, LocalFontSource, Provider, ProviderContext, ProviderDefinition, ProviderFactory, RemoteFontSource, ResolveFontOptions } from './types'
+export type { Unifont, UnifontOptions } from './unifont'
+
+export { createUnifont, defaultResolveOptions } from './unifont'
 export { defineFontProvider } from './utils'

--- a/src/unifont.ts
+++ b/src/unifont.ts
@@ -1,10 +1,5 @@
 import type { Storage } from './cache'
-import type {
-  InitializedProvider,
-  Provider,
-  ResolveFontOptions,
-  ResolveFontResult,
-} from './types'
+import type { InitializedProvider, Provider, ResolveFontOptions, ResolveFontResult } from './types'
 import { createAsyncStorage, memoryStorage } from './cache'
 
 export interface UnifontOptions {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Working on unifont this week, I found that having `createUnifont()` in the main entrypoint was a bit confusing, as it made less clear what was re-exported from here. In this PR, I extracted it to its distinct file and keep `index.ts` as a barrel export. Will help for #288 types exports