### PR TITLE
perf(googleicons): use direct string slicing to drop first line of metadata response

### DIFF
--- a/src/providers/googleicons.ts
+++ b/src/providers/googleicons.ts
@@ -19,9 +19,12 @@ interface ProviderOptions {
 
 export default defineFontProvider('googleicons', async (_options: ProviderOptions, ctx) => {
   const googleIcons = await ctx.storage.getItem('googleicons:meta.json', async () => {
-    const response: { families: string[] } = JSON.parse((await $fetch<string>(
+    const data = await $fetch<string>(
       'https://fonts.google.com/metadata/icons?key=material_symbols&incomplete=true',
-    )).split('\n').slice(1).join('\n')) // remove the first line which makes it an invalid JSON
+    )
+    const response: { families: string[] } = JSON.parse(
+      data.substring(data.indexOf('\n') + 1), // remove the first line which makes it an invalid JSON
+    )
 
     return response.families
   })


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

This PR updates the code to remove the first line of the 340,000+ lines response from `https://fonts.google.com/metadata/icons` using direct string manipulation, which is more efficient than process with array.

