### PR TITLE
feat: export more types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export * as providers from './providers'
 
-export type { FontFaceData, FontFaceMeta, FontStyles, LocalFontSource, Provider, ProviderContext, ProviderDefinition, ProviderFactory, RemoteFontSource, ResolveFontOptions } from './types'
+export type { FontFaceData, FontFaceMeta, FontStyles, InitializedProvider, LocalFontSource, Provider, ProviderContext, ProviderDefinition, ProviderFactory, RemoteFontSource, ResolveFontOptions, ResolveFontResult } from './types'
 export type { Unifont, UnifontOptions } from './unifont'
 
 export { createUnifont, defaultResolveOptions } from './unifont'


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Working on https://github.com/withastro/astro/pull/14980 I found I need more types from unifont, that are currently not exported. Otherwise TS throws errors like `Return type of exported function has or is using name ResolveFontResult from external module but cannot be named.`
