### PR TITLE
fix(adobe): avoid clearing kit state before refresh completes

### DIFF
--- a/src/providers/adobe.ts
+++ b/src/providers/adobe.ts
@@ -36,9 +36,10 @@ export default defineFontProvider('adobe', async (options: AdobeProviderOptions,
   await fetchKits()
 
   async function fetchKits(bypassCache: boolean = false) {
-    familyMap.clear()
-    notFoundFamilies.clear()
-    fonts.kits = []
+    // Build new state and swap atomically at the end so concurrent readers
+    // never observe a cleared familyMap / fonts.kits while the refresh is in flight.
+    const newKits: AdobeFontKit[] = []
+    const newFamilyMap = new Map<string, string>()
 
     await Promise.all(kits.map(async (id) => {
       let meta: AdobeFontKit
@@ -55,11 +56,18 @@ export default defineFontProvider('adobe', async (options: AdobeProviderOptions,
         throw new TypeError('No font metadata found in adobe response.')
       }
 
-      fonts.kits.push(meta)
+      newKits.push(meta)
       for (const family of meta.families) {
-        familyMap.set(family.name, family.id)
+        newFamilyMap.set(family.name, family.id)
       }
     }))
+
+    familyMap.clear()
+    notFoundFamilies.clear()
+    fonts.kits = newKits
+    for (const [k, v] of newFamilyMap) {
+      familyMap.set(k, v)
+    }
   }
 
   async function getFontDetails(family: string, options: ResolveFontOptions) {

--- a/test/providers/adobe.test.ts
+++ b/test/providers/adobe.test.ts
@@ -201,6 +201,86 @@ describe('adobe', () => {
     }
   })
 
+  it('resolves adobe fonts correctly when a concurrent refresh clears state mid-flight', async () => {
+    const originalFetch = globalThis.fetch
+
+    globalThis.fetch = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes('typekit.com/api/v1/json/kits/clearrace/published')) {
+        await new Promise(resolve => setTimeout(resolve, 50))
+        return new Response(JSON.stringify({
+          kit: {
+            id: 'clearrace',
+            families: [
+              {
+                id: 'aleo',
+                name: 'Aleo',
+                slug: 'aleo',
+                css_names: ['aleo'],
+                css_stack: 'aleo, serif',
+                variations: ['n4', 'i4'],
+              },
+              {
+                id: 'barlow',
+                name: 'Barlow',
+                slug: 'barlow',
+                css_names: ['barlow'],
+                css_stack: 'barlow, sans-serif',
+                variations: ['n4'],
+              },
+            ],
+          },
+        }), { status: 200, headers: { 'content-type': 'application/json' } })
+      }
+      else if (url.includes('clearrace.css')) {
+        await new Promise(resolve => setTimeout(resolve, 50))
+        return new Response(`
+          @font-face {
+            font-family: "aleo";
+            src: url("https://use.typekit.net/aleo.woff2") format("woff2");
+            font-weight: 400;
+            font-style: normal;
+          }
+          @font-face {
+            font-family: "barlow";
+            src: url("https://use.typekit.net/barlow.woff2") format("woff2");
+            font-weight: 400;
+            font-style: normal;
+          }
+        `, { status: 200, headers: { 'content-type': 'text/css' } })
+      }
+      return originalFetch(url)
+    })
+
+    try {
+      const realDateNow = Date.now.bind(Date)
+      let time = realDateNow()
+      vi.spyOn(Date, 'now').mockImplementation(() => time)
+
+      const unifont = await createUnifont([providers.adobe({ id: 'clearrace' })])
+
+      // Advance time past KIT_REFRESH_TIMEOUT (5 minutes) so the next miss
+      // will trigger fetchKits(true).
+      time += 6 * 60 * 1000
+
+      // Order matters: Aleo's resolveFont must run first so its synchronous
+      // prefix passes the familyMap.has() check and yields at
+      // `await ctx.storage.getItem(...)` *before* NonExistentFont's resolveFont
+      // synchronously clears familyMap / fonts.kits at the top of fetchKits.
+      const [aleo, nonExistent] = await Promise.all([
+        unifont.resolveFont('Aleo'),
+        unifont.resolveFont('NonExistentFont'),
+      ])
+
+      expect(nonExistent.fonts).toHaveLength(0)
+      expect(aleo.fonts.length).toBeGreaterThan(0)
+
+      vi.restoreAllMocks()
+    }
+    finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+
   it('refreshes kit metadata when font is not found in cache', async () => {
     let apiCallCount = 0
 


### PR DESCRIPTION
this fixes a race condition noticed in a test failure in https://github.com/nuxt/ecosystem-ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a concurrency issue that could cause font metadata loss during simultaneous font refresh operations.

* **Tests**
  * Added regression test to ensure font resolution remains reliable during concurrent refresh scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->