### PR TITLE
fix(fontsource): use standard or full variant for multi-axis fonts

### DIFF
--- a/src/providers/fontsource.ts
+++ b/src/providers/fontsource.ts
@@ -6,6 +6,21 @@ import { cleanFontFaces, defineFontProvider, prepareWeights } from '../utils'
 
 const fontAPI = $fetch.create({ baseURL: 'https://api.fontsource.org/v1' })
 
+// registered OpenType axes served via the fontsource `standard` variant
+const FONTSOURCE_REGISTERED_AXES = new Set(['wght', 'ital', 'slnt', 'wdth', 'opsz'])
+
+function pickFontsourceAxisSlug(axes: string[]): 'wght' | 'standard' | 'full' {
+  let hasRegisteredExtra = false
+  for (const axis of axes) {
+    if (axis === 'wght' || axis === 'ital')
+      continue
+    if (!FONTSOURCE_REGISTERED_AXES.has(axis))
+      return 'full'
+    hasRegisteredExtra = true
+  }
+  return hasRegisteredExtra ? 'standard' : 'wght'
+}
+
 export default defineFontProvider('fontsource', async (_options, ctx) => {
   const fonts = await ctx.storage.getItem('fontsource:meta.json', () => fontAPI<FontsourceFontMeta[]>('/fonts', { responseType: 'json' }))
   const familyMap = new Map<string, FontsourceFontMeta>()
@@ -36,11 +51,12 @@ export default defineFontProvider('fontsource', async (_options, ctx) => {
             try {
               const variableAxes = await ctx.storage.getItem(`fontsource:${font.family}-axes.json`, () => fontAPI<FontsourceVariableFontDetail>(`/variable/${font.id}`, { responseType: 'json' }))
               if (variableAxes && variableAxes.axes.wght) {
+                const axisSlug = pickFontsourceAxisSlug(Object.keys(variableAxes.axes))
                 fontFaceData.push({
                   style,
                   weight: [Number(variableAxes.axes.wght.min), Number(variableAxes.axes.wght.max)],
                   src: [
-                    { url: `https://cdn.jsdelivr.net/fontsource/fonts/${font.id}:vf@latest/${subset}-wght-${style}.woff2`, format: 'woff2' },
+                    { url: `https://cdn.jsdelivr.net/fontsource/fonts/${font.id}:vf@latest/${subset}-${axisSlug}-${style}.woff2`, format: 'woff2' },
                   ],
                   unicodeRange: fontDetail.unicodeRange[subset]?.split(','),
                   meta: { subset },

--- a/test/providers/fontsource.test.ts
+++ b/test/providers/fontsource.test.ts
@@ -339,6 +339,27 @@ describe('fontsource', () => {
     expect(fonts.some(fnt => Array.isArray(fnt.weight))).toBe(true)
   })
 
+  it('uses the wght variant for fonts whose only variable axis is wght', async () => {
+    const unifont = await createUnifont([providers.fontsource()])
+    const { fonts } = await unifont.resolveFont('Roboto Mono', { weights: ['400 700'], subsets: ['latin'], styles: ['normal'] })
+    const variable = fonts.find(fnt => Array.isArray(fnt.weight))!
+    expect(variable.src[0]).toMatchObject({ url: 'https://cdn.jsdelivr.net/fontsource/fonts/roboto-mono:vf@latest/latin-wght-normal.woff2' })
+  })
+
+  it('uses the standard variant when extra registered axes are present', async () => {
+    const unifont = await createUnifont([providers.fontsource()])
+    const { fonts } = await unifont.resolveFont('Inter', { weights: ['100 900'], subsets: ['latin'], styles: ['normal'] })
+    const variable = fonts.find(fnt => Array.isArray(fnt.weight))!
+    expect(variable.src[0]).toMatchObject({ url: 'https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-standard-normal.woff2' })
+  })
+
+  it('uses the full variant when custom axes are present', async () => {
+    const unifont = await createUnifont([providers.fontsource()])
+    const { fonts } = await unifont.resolveFont('Fraunces', { weights: ['100 900'], subsets: ['latin'], styles: ['normal'] })
+    const variable = fonts.find(fnt => Array.isArray(fnt.weight))!
+    expect(variable.src[0]).toMatchObject({ url: 'https://cdn.jsdelivr.net/fontsource/fonts/fraunces:vf@latest/latin-full-normal.woff2' })
+  })
+
   it('handles default subsets', async () => {
     const unifont = await createUnifont([providers.fontsource()])
     const { fonts } = await unifont.resolveFont('Roboto Mono', { subsets: undefined })


### PR DESCRIPTION
Fontsource serves variable fonts at three URL slugs: `wght` (weight only), `standard` (weight plus the registered OpenType axes opsz/wdth/slnt), and `full` (custom axes such as opsz, SOFT, WONK, MONO). The provider always picked `wght`, so user-supplied `variationSettings` for non-wght axes silently had no effect because those axes are absent from the served file. The fix inspects the axes returned by `/variable/{id}` and picks the narrowest slug that actually carries them.

Closes #374

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced variable font support with intelligent variant selection that automatically chooses the appropriate axis configuration based on the font's available OpenType features.

* **Tests**
  * Added comprehensive test cases to verify variable font variant selection works correctly across different axis configurations and font capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/unifont/pull/393)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->