### PR TITLE
feat: return fallbacks from `resolveFont()` when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ const unifont = await createUnifont([
 ])
 
 const availableFonts = await unifont.listFonts()
-const { fonts } = await unifont.resolveFont('Poppins')
+const { fonts, fallbacks } = await unifont.resolveFont('Poppins')
 ```
 
 ## Built-in providers
@@ -481,7 +481,7 @@ const unifont = await createUnifont([
 
 - Type: `(fontFamily: string, options?: Partial<ResolveFontOptions>, providers?: T[]) => Promise<ResolveFontResult & { provider?: T }>`
 
-Retrieves font face data from available providers:
+Retrieves font face data and fallbacks from available providers:
 
 ```js
 import { createUnifont, providers } from 'unifont'
@@ -491,10 +491,12 @@ const unifont = await createUnifont([
   providers.fontsource(),
 ])
 
-const { fonts } = await unifont.resolveFont('Poppins')
+const { fonts, fallbacks } = await unifont.resolveFont('Poppins')
 ```
 
 It loops through all providers and returns the result of the first provider that can return some data.
+
+Fallbacks, if returned, contain the name of a [generic font family](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-family#generic-name). That can be useful, for example, to generate optimized fallbacks using font metrics.
 
 ##### Options
 

--- a/src/providers/bunny.ts
+++ b/src/providers/bunny.ts
@@ -7,6 +7,15 @@ import { cleanFontFaces, defineFontProvider, prepareWeights, splitCssIntoSubsets
 
 const fontAPI = $fetch.create({ baseURL: 'https://fonts.bunny.net' })
 
+// There are also display and handwriting but these are not valid
+const VALID_FALLBACKS = ['sans-serif', 'serif', 'monospace']
+
+function getFallbacks(category: string): string[] | undefined {
+  if (VALID_FALLBACKS.includes(category))
+    return [category]
+  return undefined
+}
+
 export default defineFontProvider('bunny', async (_options, ctx) => {
   const familyMap = new Map<string, string>()
 
@@ -15,9 +24,7 @@ export default defineFontProvider('bunny', async (_options, ctx) => {
     familyMap.set(family.familyName, id)
   }
 
-  async function getFontDetails(family: string, options: ResolveFontOptions) {
-    const id = familyMap.get(family) as keyof typeof fonts
-    const font = fonts[id]!
+  async function getFontDetails(id: string, font: BunnyFontMeta[string], options: ResolveFontOptions) {
     const weights = prepareWeights({
       inputWeights: options.weights,
       hasVariableWeights: false,
@@ -63,12 +70,17 @@ export default defineFontProvider('bunny', async (_options, ctx) => {
       return [...familyMap.keys()]
     },
     async resolveFont(fontFamily, defaults) {
-      if (!familyMap.has(fontFamily)) {
+      const id = familyMap.get(fontFamily)
+      if (!id) {
         return
       }
 
-      const fonts = await ctx.storage.getItem(`bunny:${fontFamily}-${hash(defaults)}-data.json`, () => getFontDetails(fontFamily, defaults))
-      return { fonts }
+      const font = fonts[id]!
+
+      return {
+        fonts: await ctx.storage.getItem(`bunny:${fontFamily}-${hash(defaults)}-data.json`, () => getFontDetails(id, font, defaults)),
+        fallbacks: getFallbacks(font.category),
+      }
     },
   }
 })

--- a/src/providers/bunny.ts
+++ b/src/providers/bunny.ts
@@ -7,7 +7,7 @@ import { cleanFontFaces, defineFontProvider, prepareWeights, splitCssIntoSubsets
 
 const fontAPI = $fetch.create({ baseURL: 'https://fonts.bunny.net' })
 
-// There are also display and handwriting but these are not valid
+// There are others like display and handwriting but these are not valid
 const VALID_FALLBACKS = ['sans-serif', 'serif', 'monospace']
 
 function getFallbacks(category: string): string[] | undefined {

--- a/src/providers/fontshare.ts
+++ b/src/providers/fontshare.ts
@@ -6,6 +6,15 @@ import { $fetch } from '../fetch'
 import { cleanFontFaces, defineFontProvider, prepareWeights } from '../utils'
 
 const fontAPI = $fetch.create({ baseURL: 'https://api.fontshare.com/v2' })
+
+function getFallbacks(category: string): string[] | undefined {
+  if (category.includes('Serif'))
+    return ['serif']
+  if (category.includes('Sans'))
+    return ['sans-serif']
+  return undefined
+}
+
 export default defineFontProvider('fontshare', async (_options, ctx) => {
   const fontshareFamilies = new Set<string>()
 
@@ -31,9 +40,7 @@ export default defineFontProvider('fontshare', async (_options, ctx) => {
     fontshareFamilies.add(font.name)
   }
 
-  async function getFontDetails(family: string, options: ResolveFontOptions) {
-  // https://api.fontshare.com/v2/css?f[]=alpino@300
-    const font = fonts.find(f => f.name === family)!
+  async function getFontDetails(font: FontshareFontMeta, options: ResolveFontOptions) {
     const numbers: number[] = []
 
     const weights = prepareWeights({
@@ -73,9 +80,13 @@ export default defineFontProvider('fontshare', async (_options, ctx) => {
         return
       }
 
-      const fonts = await ctx.storage.getItem(`fontshare:${fontFamily}-${hash(defaults)}-data.json`, () => getFontDetails(fontFamily, defaults))
+      // https://api.fontshare.com/v2/css?f[]=alpino@300
+      const font = fonts.find(f => f.name === fontFamily)!
 
-      return { fonts }
+      return {
+        fonts: await ctx.storage.getItem(`fontshare:${fontFamily}-${hash(defaults)}-data.json`, () => getFontDetails(font, defaults)),
+        fallbacks: getFallbacks(font.category),
+      }
     },
   }
 })
@@ -85,6 +96,7 @@ export default defineFontProvider('fontshare', async (_options, ctx) => {
 interface FontshareFontMeta {
   slug: string
   name: string
+  category: string
   styles: Array<{
     default: boolean
     file: string

--- a/src/providers/fontsource.ts
+++ b/src/providers/fontsource.ts
@@ -21,6 +21,15 @@ function pickFontsourceAxisSlug(axes: string[]): 'wght' | 'standard' | 'full' {
   return hasRegisteredExtra ? 'standard' : 'wght'
 }
 
+// There are others like display and handwriting but these are not valid
+const VALID_FALLBACKS = ['sans-serif', 'serif', 'monospace']
+
+function getFallbacks(category: string): string[] | undefined {
+  if (VALID_FALLBACKS.includes(category))
+    return [category]
+  return undefined
+}
+
 export default defineFontProvider('fontsource', async (_options, ctx) => {
   const fonts = await ctx.storage.getItem('fontsource:meta.json', () => fontAPI<FontsourceFontMeta[]>('/fonts', { responseType: 'json' }))
   const familyMap = new Map<string, FontsourceFontMeta>()
@@ -29,8 +38,7 @@ export default defineFontProvider('fontsource', async (_options, ctx) => {
     familyMap.set(meta.family, meta)
   }
 
-  async function getFontDetails(family: string, options: ResolveFontOptions) {
-    const font = familyMap.get(family)!
+  async function getFontDetails(font: FontsourceFontMeta, options: ResolveFontOptions) {
     const weights = prepareWeights({
       inputWeights: options.weights,
       hasVariableWeights: font.variable,
@@ -89,12 +97,15 @@ export default defineFontProvider('fontsource', async (_options, ctx) => {
       return [...familyMap.keys()]
     },
     async resolveFont(fontFamily, options) {
-      if (!familyMap.has(fontFamily)) {
+      const font = familyMap.get(fontFamily)
+      if (!font) {
         return
       }
 
-      const fonts = await ctx.storage.getItem(`fontsource:${fontFamily}-${hash(options)}-data.json`, () => getFontDetails(fontFamily, options))
-      return { fonts }
+      return {
+        fonts: await ctx.storage.getItem(`fontsource:${fontFamily}-${hash(options)}-data.json`, () => getFontDetails(font, options)),
+        fallbacks: getFallbacks(font.category),
+      }
     },
   }
 })

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -47,6 +47,20 @@ export const userAgents: Partial<Record<FontFormat, string>> = {
   woff2: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36',
 }
 
+// There are others like display and handwriting but these are not valid
+const VALID_FALLBACKS: Record<string, string> = {
+  'Sans Serif': 'sans-serif',
+  'Serif': 'serif',
+  'Monospace': 'monospace',
+}
+
+function getFallbacks(category: string): string[] | undefined {
+  const fallback = VALID_FALLBACKS[category]
+  if (fallback)
+    return [fallback]
+  return undefined
+}
+
 export default defineFontProvider('google', async (providerOptions: GoogleProviderOptions, ctx) => {
   const googleFonts = await ctx.storage.getItem('google:meta.json', () => $fetch<{ familyMetadataList: FontIndexMeta[] }>('https://fonts.google.com/metadata/fonts', { responseType: 'json' }).then(r => r.familyMetadataList))
 
@@ -56,10 +70,9 @@ export default defineFontProvider('google', async (providerOptions: GoogleProvid
     normal: '0',
   }
 
-  async function getFontDetails(family: string, options: ResolveFontOptions<GoogleFamilyOptions>) {
-    const font = googleFonts.find(font => font.family === family)!
+  async function getFontDetails(font: FontIndexMeta, options: ResolveFontOptions<GoogleFamilyOptions>) {
     const styles = [...new Set(options.styles.map(i => styleMap[i]))].sort()
-    const glyphs = (options.options?.experimental?.glyphs ?? providerOptions.experimental?.glyphs?.[family])?.join('')
+    const glyphs = (options.options?.experimental?.glyphs ?? providerOptions.experimental?.glyphs?.[font.family])?.join('')
     const weights = prepareWeights({
       inputWeights: options.weights,
       hasVariableWeights: font.axes.some(a => a.tag === 'wght'),
@@ -76,7 +89,7 @@ export default defineFontProvider('google', async (providerOptions: GoogleProvid
 
     const resolvedAxes = []
     let resolvedVariants: string[] = []
-    const variableAxis = options.options?.experimental?.variableAxis ?? providerOptions.experimental?.variableAxis?.[family]
+    const variableAxis = options.options?.experimental?.variableAxis ?? providerOptions.experimental?.variableAxis?.[font.family]
     const candidateAxes = [
       'wght',
       'ital',
@@ -112,7 +125,7 @@ export default defineFontProvider('google', async (providerOptions: GoogleProvid
           'user-agent': userAgent,
         },
         query: {
-          family: `${family}:${resolvedAxes.join(',')}@${resolvedVariants.join(
+          family: `${font.family}:${resolvedAxes.join(',')}@${resolvedVariants.join(
             ';',
           )}`,
           ...(glyphs && { text: glyphs }),
@@ -142,12 +155,15 @@ export default defineFontProvider('google', async (providerOptions: GoogleProvid
       return googleFonts.map(font => font.family)
     },
     async resolveFont(fontFamily, options: ResolveFontOptions<GoogleFamilyOptions>) {
-      if (!googleFonts.some(font => font.family === fontFamily)) {
+      const font = googleFonts.find(font => font.family === fontFamily)
+      if (!font) {
         return
       }
 
-      const fonts = await ctx.storage.getItem(`google:${fontFamily}-${hash(options)}-data.json`, () => getFontDetails(fontFamily, options))
-      return { fonts }
+      return {
+        fonts: await ctx.storage.getItem(`google:${fontFamily}-${hash(options)}-data.json`, () => getFontDetails(font, options)),
+        fallbacks: getFallbacks(font.category),
+      }
     },
   }
 })
@@ -157,6 +173,7 @@ export default defineFontProvider('google', async (providerOptions: GoogleProvid
 interface FontIndexMeta {
   family: string
   subsets: string[]
+  category: string
   fonts: Record<string, {
     thickness: number | null
     slant: number | null

--- a/test/providers/bunny.test.ts
+++ b/test/providers/bunny.test.ts
@@ -143,4 +143,36 @@ describe('bunny', () => {
       expect([...new Set(fonts.flatMap(font => font.src.map(source => 'name' in source ? source.name : source.format)))]).toStrictEqual(['woff2', 'woff'])
     })
   })
+
+  describe('fallbacks', () => {
+    it('returns sans-serif fallback', async () => {
+      const unifont = await createUnifont([providers.bunny()])
+      const { fallbacks } = await unifont.resolveFont('ABeeZee')
+      expect(fallbacks).toStrictEqual(['sans-serif'])
+    })
+
+    it('returns serif fallback', async () => {
+      const unifont = await createUnifont([providers.bunny()])
+      const { fallbacks } = await unifont.resolveFont('Abhaya Libre')
+      expect(fallbacks).toStrictEqual(['serif'])
+    })
+
+    it('returns monospace fallback', async () => {
+      const unifont = await createUnifont([providers.bunny()])
+      const { fallbacks } = await unifont.resolveFont('Anonymous Pro')
+      expect(fallbacks).toStrictEqual(['monospace'])
+    })
+
+    it('does not return display fallback', async () => {
+      const unifont = await createUnifont([providers.bunny()])
+      const { fallbacks } = await unifont.resolveFont('Aboreto')
+      expect(fallbacks).toBeUndefined()
+    })
+
+    it('does not return handwriting fallback', async () => {
+      const unifont = await createUnifont([providers.bunny()])
+      const { fallbacks } = await unifont.resolveFont('Aguafina Script')
+      expect(fallbacks).toBeUndefined()
+    })
+  })
 })

--- a/test/providers/bunny.test.ts
+++ b/test/providers/bunny.test.ts
@@ -163,15 +163,9 @@ describe('bunny', () => {
       expect(fallbacks).toStrictEqual(['monospace'])
     })
 
-    it('does not return display fallback', async () => {
+    it('does not return invalid fallback', async () => {
       const unifont = await createUnifont([providers.bunny()])
       const { fallbacks } = await unifont.resolveFont('Aboreto')
-      expect(fallbacks).toBeUndefined()
-    })
-
-    it('does not return handwriting fallback', async () => {
-      const unifont = await createUnifont([providers.bunny()])
-      const { fallbacks } = await unifont.resolveFont('Aguafina Script')
       expect(fallbacks).toBeUndefined()
     })
   })

--- a/test/providers/fontshare.test.ts
+++ b/test/providers/fontshare.test.ts
@@ -136,4 +136,24 @@ describe('fontshare', () => {
       expect(fonts.flatMap(font => font.src.map(source => 'name' in source ? source.name : source.format))).toStrictEqual(['woff2', 'woff', 'truetype'])
     })
   })
+
+  describe('fallbacks', () => {
+    it('returns sans-serif fallback', async () => {
+      const unifont = await createUnifont([providers.fontshare()])
+      const { fallbacks } = await unifont.resolveFont('Epilogue')
+      expect(fallbacks).toStrictEqual(['sans-serif'])
+    })
+
+    it('returns serif fallback', async () => {
+      const unifont = await createUnifont([providers.fontshare()])
+      const { fallbacks } = await unifont.resolveFont('Rowan')
+      expect(fallbacks).toStrictEqual(['serif'])
+    })
+
+    it('does not return display fallback', async () => {
+      const unifont = await createUnifont([providers.fontshare()])
+      const { fallbacks } = await unifont.resolveFont('Kihim')
+      expect(fallbacks).toBeUndefined()
+    })
+  })
 })

--- a/test/providers/fontshare.test.ts
+++ b/test/providers/fontshare.test.ts
@@ -150,7 +150,7 @@ describe('fontshare', () => {
       expect(fallbacks).toStrictEqual(['serif'])
     })
 
-    it('does not return display fallback', async () => {
+    it('does not return invalid fallback', async () => {
       const unifont = await createUnifont([providers.fontshare()])
       const { fallbacks } = await unifont.resolveFont('Kihim')
       expect(fallbacks).toBeUndefined()

--- a/test/providers/fontsource.test.ts
+++ b/test/providers/fontsource.test.ts
@@ -537,4 +537,30 @@ describe('fontsource', () => {
       expect(fonts.flatMap(font => font.src.map(source => 'name' in source ? source.name : source.format))).toStrictEqual(['woff2', 'woff', 'truetype'])
     })
   })
+
+  describe('fallbacks', () => {
+    it('returns sans-serif fallback', async () => {
+      const unifont = await createUnifont([providers.fontsource()])
+      const { fallbacks } = await unifont.resolveFont('ABeeZee')
+      expect(fallbacks).toStrictEqual(['sans-serif'])
+    })
+
+    it('returns serif fallback', async () => {
+      const unifont = await createUnifont([providers.fontsource()])
+      const { fallbacks } = await unifont.resolveFont('Abhaya Libre')
+      expect(fallbacks).toStrictEqual(['serif'])
+    })
+
+    it('returns monospace fallback', async () => {
+      const unifont = await createUnifont([providers.fontsource()])
+      const { fallbacks } = await unifont.resolveFont('Anonymous Pro')
+      expect(fallbacks).toStrictEqual(['monospace'])
+    })
+
+    it('does not return invalid fallback', async () => {
+      const unifont = await createUnifont([providers.fontsource()])
+      const { fallbacks } = await unifont.resolveFont('Aboreto')
+      expect(fallbacks).toBeUndefined()
+    })
+  })
 })

--- a/test/providers/google.test.ts
+++ b/test/providers/google.test.ts
@@ -307,4 +307,30 @@ describe('google', () => {
       expect(fonts.flatMap(font => font.src.map(source => 'name' in source ? source.name : source.format))).toStrictEqual(['woff2', 'woff', 'truetype', undefined])
     })
   })
+
+  describe('fallbacks', () => {
+    it('returns sans-serif fallback', async () => {
+      const unifont = await createUnifont([providers.google()])
+      const { fallbacks } = await unifont.resolveFont('ABeeZee')
+      expect(fallbacks).toStrictEqual(['sans-serif'])
+    })
+
+    it('returns serif fallback', async () => {
+      const unifont = await createUnifont([providers.google()])
+      const { fallbacks } = await unifont.resolveFont('Abhaya Libre')
+      expect(fallbacks).toStrictEqual(['serif'])
+    })
+
+    it('returns monospace fallback', async () => {
+      const unifont = await createUnifont([providers.google()])
+      const { fallbacks } = await unifont.resolveFont('Anonymous Pro')
+      expect(fallbacks).toStrictEqual(['monospace'])
+    })
+
+    it('does not return invalid fallback', async () => {
+      const unifont = await createUnifont([providers.google()])
+      const { fallbacks } = await unifont.resolveFont('Aboreto')
+      expect(fallbacks).toBeUndefined()
+    })
+  })
 })


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

This PR updates the bunny, fontshare, fontsource and google providers so they return `fallbacks` from `resolveFont()` when possible. This is useful for optimized fallback generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The `resolveFont()` function now returns generic CSS fallback font families (sans-serif, serif, monospace) alongside resolved font data, enabling graceful font degradation when primary fonts are unavailable.

* **Documentation**
  * Updated documentation and code examples to reflect the new return structure with both fonts and fallback families.

* **Tests**
  * Added test coverage validating fallback font family returns across all supported font providers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/unifont/pull/399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->