### PR TITLE
feat: honour `HTTPS_PROXY` env var for outbound fetches

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ const availableFonts = await unifont.listFonts()
 const { fonts } = await unifont.resolveFont('Poppins')
 ```
 
+`unifont` honours the `HTTPS_PROXY` / `HTTP_PROXY` (and lower-case) environment variables for outbound font metadata and binary fetches at build time, so it works behind corporate proxies without extra configuration.
+
 ## Built-in providers
 
 The following providers are built-in but you can build [custom providers](#building-your-own-provider) too.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "dependencies": {
     "css-tree": "^3.1.0",
     "ofetch": "^1.5.1",
-    "ohash": "^2.0.11"
+    "ohash": "^2.0.11",
+    "undici": "^7.18.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "7.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       ohash:
         specifier: ^2.0.11
         version: 2.0.11
+      undici:
+        specifier: ^7.18.0
+        version: 7.25.0
     devDependencies:
       '@antfu/eslint-config':
         specifier: 7.3.0
@@ -2400,6 +2403,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -5089,6 +5096,8 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@7.16.0: {}
+
+  undici@7.25.0: {}
 
   unicorn-magic@0.3.0: {}
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -16,11 +16,12 @@ let installed = false
 export async function installProxyDispatcher(): Promise<void> {
   if (installed)
     return
-  installed = true
 
   const proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.https_proxy || process.env.http_proxy
   if (!proxyUrl)
     return
+
+  installed = true
 
   try {
     const { Agent, EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } = await import('undici')

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,35 @@
+// Node's built-in `fetch` (undici) ignores `HTTPS_PROXY` / `HTTP_PROXY`
+// unless launched with `node --use-env-proxy` (Node 24+, experimental).
+//
+// We wire up undici's `EnvHttpProxyAgent` as the global dispatcher when
+// a proxy env var is present and the user has not already installed their own
+// dispatcher (custom `ProxyAgent`, `MockAgent`, undici interceptors, ...).
+//
+// See:
+//   https://nodejs.org/api/cli.html#--use-env-proxy
+//   https://undici.nodejs.org/#/docs/api/EnvHttpProxyAgent
+
+import process from 'node:process'
+
+let installed = false
+
+export async function installProxyDispatcher(): Promise<void> {
+  if (installed)
+    return
+  installed = true
+
+  const proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.https_proxy || process.env.http_proxy
+  if (!proxyUrl)
+    return
+
+  try {
+    const { Agent, EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } = await import('undici')
+    const current = getGlobalDispatcher()
+    if (current instanceof Agent && !(current instanceof EnvHttpProxyAgent)) {
+      setGlobalDispatcher(new EnvHttpProxyAgent())
+    }
+  }
+  catch {
+    // 🤷‍♂️ what can you do?
+  }
+}

--- a/src/unifont.ts
+++ b/src/unifont.ts
@@ -1,6 +1,7 @@
 import type { Storage } from './cache'
 import type { InitializedProvider, Provider, ProviderContext, ResolveFontOptions, ResolveFontResult } from './types'
 import { createAsyncStorage, memoryStorage } from './cache'
+import { installProxyDispatcher } from './proxy'
 
 export interface UnifontOptions {
   storage?: Storage
@@ -39,6 +40,8 @@ export const defaultResolveOptions: ResolveFontOptions = {
 }
 
 export async function createUnifont<T extends [Provider, ...Provider[]]>(providers: T, unifontOptions?: UnifontOptions): Promise<Unifont<T>> {
+  await installProxyDispatcher()
+
   const stack: Record<string, InitializedProvider> = {}
 
   const storage = unifontOptions?.storage ?? memoryStorage()

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -1,0 +1,89 @@
+import { Agent, EnvHttpProxyAgent, getGlobalDispatcher, ProxyAgent, setGlobalDispatcher } from 'undici'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function freshInstall(): Promise<() => Promise<void>> {
+  vi.resetModules()
+  const { installProxyDispatcher } = await import('../src/proxy')
+  return installProxyDispatcher
+}
+
+describe('installProxyDispatcher', () => {
+  const originalDispatcher = getGlobalDispatcher()
+  const proxyEnvKeys = ['HTTPS_PROXY', 'HTTP_PROXY', 'https_proxy', 'http_proxy'] as const
+  const savedEnv: Partial<Record<typeof proxyEnvKeys[number], string | undefined>> = {}
+
+  beforeEach(() => {
+    for (const key of proxyEnvKeys) {
+      savedEnv[key] = process.env[key]
+      delete process.env[key]
+    }
+  })
+
+  afterEach(() => {
+    for (const key of proxyEnvKeys) {
+      if (savedEnv[key] === undefined)
+        delete process.env[key]
+      else
+        process.env[key] = savedEnv[key]
+    }
+    setGlobalDispatcher(originalDispatcher)
+  })
+
+  it('does nothing when no proxy env var is set', async () => {
+    const before = getGlobalDispatcher()
+    const install = await freshInstall()
+    await install()
+    expect(getGlobalDispatcher()).toBe(before)
+  })
+
+  it('installs EnvHttpProxyAgent when HTTPS_PROXY is set', async () => {
+    process.env.HTTPS_PROXY = 'http://127.0.0.1:9999'
+    const install = await freshInstall()
+    await install()
+    expect(getGlobalDispatcher()).toBeInstanceOf(EnvHttpProxyAgent)
+  })
+
+  it('honours lower-case https_proxy', async () => {
+    process.env.https_proxy = 'http://127.0.0.1:9999'
+    const install = await freshInstall()
+    await install()
+    expect(getGlobalDispatcher()).toBeInstanceOf(EnvHttpProxyAgent)
+  })
+
+  it('honours HTTP_PROXY when HTTPS_PROXY is unset', async () => {
+    process.env.HTTP_PROXY = 'http://127.0.0.1:9999'
+    const install = await freshInstall()
+    await install()
+    expect(getGlobalDispatcher()).toBeInstanceOf(EnvHttpProxyAgent)
+  })
+
+  it('does not trample a user-installed custom dispatcher', async () => {
+    process.env.HTTPS_PROXY = 'http://127.0.0.1:9999'
+    const custom = new ProxyAgent('http://127.0.0.1:8888')
+    setGlobalDispatcher(custom)
+    const install = await freshInstall()
+    await install()
+    expect(getGlobalDispatcher()).toBe(custom)
+    expect(getGlobalDispatcher()).not.toBeInstanceOf(EnvHttpProxyAgent)
+  })
+
+  it('is idempotent across repeated calls', async () => {
+    process.env.HTTPS_PROXY = 'http://127.0.0.1:9999'
+    const install = await freshInstall()
+    await install()
+    const first = getGlobalDispatcher()
+    await install()
+    expect(getGlobalDispatcher()).toBe(first)
+  })
+
+  it('retries if env vars are not present on the first call', async () => {
+    const install = await freshInstall()
+    await install()
+    expect(getGlobalDispatcher()).toBeInstanceOf(Agent)
+    expect(getGlobalDispatcher()).not.toBeInstanceOf(EnvHttpProxyAgent)
+
+    process.env.HTTPS_PROXY = 'http://127.0.0.1:9999'
+    await install()
+    expect(getGlobalDispatcher()).toBeInstanceOf(EnvHttpProxyAgent)
+  })
+})


### PR DESCRIPTION
this adds `undici` as a dep + honors `HTTPS_PROXY`/`HTTP_PROXY` environment variables if set and not otherwise configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for HTTP/HTTPS proxy via environment variables (`HTTPS_PROXY`, `HTTP_PROXY`, and lowercase variants), allowing builds to fetch font data behind corporate proxies without extra setup.

* **Documentation**
  * README updated to document proxy environment variable support and usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/unifont/pull/404?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->