### PR TITLE
feat(fontshare): support variable weights

### DIFF
--- a/src/providers/fontshare.ts
+++ b/src/providers/fontshare.ts
@@ -43,9 +43,15 @@ export default defineFontProvider('fontshare', async (_options, ctx) => {
   async function getFontDetails(font: FontshareFontMeta, options: ResolveFontOptions) {
     const numbers: number[] = []
 
+    let axis
+    const hasVariable = font.styles.some(e => e.is_variable)
+    if (hasVariable) {
+      axis = font.axes.find(e => e.property === 'wght')
+    }
+
     const weights = prepareWeights({
       inputWeights: options.weights,
-      hasVariableWeights: false,
+      hasVariableWeights: hasVariable && !!axis,
       weights: font.styles.map(s => String(s.weight.weight)),
     }).map(w => w.weight)
 
@@ -56,7 +62,10 @@ export default defineFontProvider('fontshare', async (_options, ctx) => {
       if (!style.is_italic && !options.styles.includes('normal')) {
         continue
       }
-      if (!weights.includes(String(style.weight.weight))) {
+      if (style.is_variable && axis && !weights.includes(`${axis.range_left} ${axis.range_right}`)) {
+        continue
+      }
+      if (!style.is_variable && !weights.includes(String(style.weight.weight))) {
         continue
       }
       numbers.push(style.weight.number)
@@ -67,7 +76,6 @@ export default defineFontProvider('fontshare', async (_options, ctx) => {
 
     const css = await fontAPI<string>(`/css?f[]=${`${font.slug}@${numbers.join(',')}`}`)
 
-    // TODO: support axes
     return cleanFontFaces(extractFontFaceData(css), options.formats)
   }
 
@@ -120,5 +128,12 @@ interface FontshareFontMeta {
       number: number
       weight: number
     }
+  }>
+  axes: Array<{
+    name: string
+    property: 'wght' | 'ital' | 'opsz'
+    range_default: number
+    range_left: number
+    range_right: number
   }>
 }

--- a/test/providers/fontshare.test.ts
+++ b/test/providers/fontshare.test.ts
@@ -51,6 +51,12 @@ describe('fontshare', () => {
     `)
   })
 
+  it('supports variable fonts', async () => {
+    const unifont = await createUnifont([providers.fontshare()])
+    const { fonts } = await unifont.resolveFont('Satoshi', { weights: ['300 900'] })
+    expect(fonts.some(fnt => Array.isArray(fnt.weight))).toBe(true)
+  })
+
   it('handles listFonts correctly', async () => {
     const unifont = await createUnifont([providers.fontshare()])
     const names = await unifont.listFonts()


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Adds support for variable weights for the fontshare provider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved variable font support for Fontshare provider with automatic detection of weight axes and proper handling of variable weight ranges during font resolution.

* **Tests**
  * Added test to verify that Fontshare fonts with variable weights are correctly resolved and handled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/unifont/pull/406?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->