### PR TITLE
perf: remove `ofetch` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "dependencies": {
     "css-tree": "^3.1.0",
-    "ofetch": "^1.5.1",
     "ohash": "^2.0.11",
     "undici": "^8.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       css-tree:
         specifier: ^3.1.0
         version: 3.2.1
-      ofetch:
-        specifier: ^1.5.1
-        version: 1.5.1
       ohash:
         specifier: ^2.0.11
         version: 2.0.11

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,15 +1,23 @@
 const RETRY_DELAY = 1000
 
+class NonRetryableError extends Error {}
+
 export async function fetchWithRetries(url: string, init?: RequestInit, retries: number = 3): Promise<Response> {
   try {
     const response = await fetch(url, init)
     if (!response.ok) {
-      throw new Error(`Fetch error (status ${response.status}): ${response.statusText}`)
+      const message = `Fetch error (status ${response.status}): ${response.statusText}`
+      // Client errors (4xx) are deterministic and won't succeed on retry, except
+      // for 429 (Too Many Requests) which is transient.
+      if (response.status >= 400 && response.status < 500 && response.status !== 429) {
+        throw new NonRetryableError(message)
+      }
+      throw new Error(message)
     }
     return response
   }
   catch (err) {
-    if (retries <= 0) {
+    if (retries <= 0 || err instanceof NonRetryableError) {
       throw err
     }
     console.warn(`Could not fetch from \`${url}\`. Will retry in \`${RETRY_DELAY}ms\`. \`${retries}\` retries left.`)

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,37 +1,19 @@
-import { ofetch } from 'ofetch'
-import * as fetchLib from './fetch'
+const RETRY_DELAY = 1000
 
-interface Mini$FetchOptions extends RequestInit {
-  baseURL?: string
-  responseType?: 'json' | 'text'
-  query?: Record<string, any>
-  retries?: number
-  retryDelay?: number
-}
-
-export function mini$fetch<T = unknown>(url: string, options?: Mini$FetchOptions): Promise<T> {
-  const retries = options?.retries ?? 3
-  const retryDelay = options?.retryDelay ?? 1000
-
-  return ofetch(url, {
-    baseURL: options?.baseURL,
-    query: options?.query,
-    responseType: options?.responseType ?? 'text',
-    headers: options?.headers,
-    retry: false,
-  }).catch((err) => {
+export async function fetchWithRetries(url: string, init?: RequestInit, retries: number = 3): Promise<Response> {
+  try {
+    const response = await fetch(url, init)
+    if (!response.ok) {
+      throw new Error(`Fetch error (status ${response.status}): ${response.statusText}`)
+    }
+    return response
+  }
+  catch (err) {
     if (retries <= 0) {
       throw err
     }
-    console.warn(`Could not fetch from \`${(options?.baseURL ?? '') + url}\`. Will retry in \`${retryDelay}ms\`. \`${retries}\` retries left.`)
-    return new Promise(resolve => setTimeout(resolve, retryDelay))
-      .then(() => fetchLib.mini$fetch(url, { ...options, retries: retries - 1 }))
-  }) as Promise<T>
+    console.warn(`Could not fetch from \`${url}\`. Will retry in \`${RETRY_DELAY}ms\`. \`${retries}\` retries left.`)
+    return new Promise(resolve => setTimeout(resolve, RETRY_DELAY))
+      .then(() => fetchWithRetries(url, init, retries - 1))
+  }
 }
-
-export const $fetch = Object.assign(mini$fetch, {
-  create: (defaults?: Mini$FetchOptions) => <T = unknown> (url: string, options?: Mini$FetchOptions) => mini$fetch<T>(url, {
-    ...defaults,
-    ...options,
-  }),
-})

--- a/src/providers/adobe.ts
+++ b/src/providers/adobe.ts
@@ -2,17 +2,15 @@ import type { ResolveFontOptions } from '../types'
 
 import { hash } from 'ohash'
 import { extractFontFaceData } from '../css/parse'
-import { $fetch } from '../fetch'
+import { fetchWithRetries } from '../fetch'
 import { defineFontProvider, prepareWeights } from '../utils'
 
 export interface AdobeProviderOptions {
   id: string[] | string
 }
 
-const fontCSSAPI = $fetch.create({ baseURL: 'https://use.typekit.net' })
-
 async function getAdobeFontMeta(id: string): Promise<AdobeFontKit> {
-  const { kit } = await $fetch<{ kit: AdobeFontKit }>(`https://typekit.com/api/v1/json/kits/${id}/published`, { responseType: 'json' })
+  const { kit } = await fetchWithRetries(`https://typekit.com/api/v1/json/kits/${id}/published`).then(res => res.json() as Promise<{ kit: AdobeFontKit }>)
   return kit
 }
 
@@ -98,7 +96,7 @@ export default defineFontProvider('adobe', async (options: AdobeProviderOptions,
       if (styles.length === 0) {
         continue
       }
-      const css = await fontCSSAPI<string>(`/${kit.id}.css`)
+      const css = await fetchWithRetries(`https://use.typekit.net/${kit.id}.css`).then(res => res.text())
 
       // TODO: Not sure whether this css_names array always has a single element. Still need to investigate.
       const cssName = font.css_names[0] ?? family.toLowerCase().split(' ').join('-')

--- a/src/providers/bunny.ts
+++ b/src/providers/bunny.ts
@@ -2,10 +2,10 @@ import type { FontFaceData, ResolveFontOptions } from '../types'
 
 import { hash } from 'ohash'
 import { extractFontFaceData } from '../css/parse'
-import { $fetch } from '../fetch'
+import { fetchWithRetries } from '../fetch'
 import { cleanFontFaces, defineFontProvider, prepareWeights, splitCssIntoSubsets } from '../utils'
 
-const fontAPI = $fetch.create({ baseURL: 'https://fonts.bunny.net' })
+const BASE_URL = 'https://fonts.bunny.net'
 
 // There are others like display and handwriting but these are not valid
 const VALID_FALLBACKS = ['sans-serif', 'serif', 'monospace']
@@ -19,7 +19,7 @@ function getFallbacks(category: string): string[] | undefined {
 export default defineFontProvider('bunny', async (_options, ctx) => {
   const familyMap = new Map<string, string>()
 
-  const fonts = await ctx.storage.getItem('bunny:meta.json', () => fontAPI<BunnyFontMeta>('/list', { responseType: 'json' }))
+  const fonts = await ctx.storage.getItem('bunny:meta.json', () => fetchWithRetries(`${BASE_URL}/list`).then(res => res.json() as Promise<BunnyFontMeta>))
   for (const [id, family] of Object.entries(fonts)) {
     familyMap.set(family.familyName, id)
   }
@@ -41,11 +41,7 @@ export default defineFontProvider('bunny', async (_options, ctx) => {
 
     const resolvedVariants = weights.flatMap(w => Array.from(styles, s => `${w.weight}${s}`))
 
-    const css = await fontAPI<string>('/css', {
-      query: {
-        family: `${id}:${resolvedVariants.join(',')}`,
-      },
-    })
+    const css = await fetchWithRetries(`${BASE_URL}/css?family=${id}:${resolvedVariants.join(',')}`).then(res => res.text())
 
     const resolvedFontFaceData: FontFaceData[] = []
 

--- a/src/providers/fontshare.ts
+++ b/src/providers/fontshare.ts
@@ -2,10 +2,10 @@ import type { ResolveFontOptions } from '../types'
 
 import { hash } from 'ohash'
 import { extractFontFaceData } from '../css/parse'
-import { $fetch } from '../fetch'
+import { fetchWithRetries } from '../fetch'
 import { cleanFontFaces, defineFontProvider, prepareWeights } from '../utils'
 
-const fontAPI = $fetch.create({ baseURL: 'https://api.fontshare.com/v2' })
+const BASE_URL = 'https://api.fontshare.com/v2'
 
 function getFallbacks(category: string): string[] | undefined {
   if (category.includes('Serif'))
@@ -23,13 +23,7 @@ export default defineFontProvider('fontshare', async (_options, ctx) => {
     let offset = 0
     let chunk
     do {
-      chunk = await fontAPI<{ fonts: FontshareFontMeta[], has_more: boolean }>('/fonts', {
-        responseType: 'json',
-        query: {
-          offset,
-          limit: 100,
-        },
-      })
+      chunk = await fetchWithRetries(`${BASE_URL}/fonts?offset=${offset}&limit=100`).then(res => res.json() as Promise<{ fonts: FontshareFontMeta[], has_more: boolean }>)
       fonts.push(...chunk.fonts)
       offset++
     } while (chunk.has_more)
@@ -74,7 +68,7 @@ export default defineFontProvider('fontshare', async (_options, ctx) => {
     if (numbers.length === 0)
       return []
 
-    const css = await fontAPI<string>(`/css?f[]=${`${font.slug}@${numbers.join(',')}`}`)
+    const css = await fetchWithRetries(`${BASE_URL}/css?f[]=${font.slug}@${numbers.join(',')}`).then(res => res.text())
 
     return cleanFontFaces(extractFontFaceData(css), options.formats)
   }

--- a/src/providers/fontsource.ts
+++ b/src/providers/fontsource.ts
@@ -1,10 +1,10 @@
 import type { FontFaceData, ResolveFontOptions } from '../types'
 
 import { hash } from 'ohash'
-import { $fetch } from '../fetch'
+import { fetchWithRetries } from '../fetch'
 import { cleanFontFaces, defineFontProvider, prepareWeights } from '../utils'
 
-const fontAPI = $fetch.create({ baseURL: 'https://api.fontsource.org/v1' })
+const BASE_URL = 'https://api.fontsource.org/v1'
 
 // registered OpenType axes served via the fontsource `standard` variant
 const FONTSOURCE_REGISTERED_AXES = new Set(['wght', 'ital', 'slnt', 'wdth', 'opsz'])
@@ -31,7 +31,7 @@ function getFallbacks(category: string): string[] | undefined {
 }
 
 export default defineFontProvider('fontsource', async (_options, ctx) => {
-  const fonts = await ctx.storage.getItem('fontsource:meta.json', () => fontAPI<FontsourceFontMeta[]>('/fonts', { responseType: 'json' }))
+  const fonts = await ctx.storage.getItem('fontsource:meta.json', () => fetchWithRetries(`${BASE_URL}/fonts`).then(res => res.json() as Promise<FontsourceFontMeta[]>))
   const familyMap = new Map<string, FontsourceFontMeta>()
 
   for (const meta of fonts) {
@@ -49,7 +49,7 @@ export default defineFontProvider('fontsource', async (_options, ctx) => {
     if (weights.length === 0 || styles.length === 0)
       return []
 
-    const fontDetail = await fontAPI<FontsourceFontDetail>(`/fonts/${font.id}`, { responseType: 'json' })
+    const fontDetail = await fetchWithRetries(`${BASE_URL}/fonts/${font.id}`).then(res => res.json() as Promise<FontsourceFontDetail>)
     const fontFaceData: FontFaceData[] = []
 
     for (const subset of subsets) {
@@ -57,7 +57,7 @@ export default defineFontProvider('fontsource', async (_options, ctx) => {
         for (const { weight, variable } of weights) {
           if (variable) {
             try {
-              const variableAxes = await ctx.storage.getItem(`fontsource:${font.family}-axes.json`, () => fontAPI<FontsourceVariableFontDetail>(`/variable/${font.id}`, { responseType: 'json' }))
+              const variableAxes = await ctx.storage.getItem(`fontsource:${font.family}-axes.json`, () => fetchWithRetries(`${BASE_URL}/variable/${font.id}`).then(res => res.json() as Promise<FontsourceVariableFontDetail>))
               if (variableAxes && variableAxes.axes.wght) {
                 const axisSlug = pickFontsourceAxisSlug(Object.keys(variableAxes.axes))
                 fontFaceData.push({

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -2,7 +2,7 @@ import type { FontFaceData, FontFormat, ResolveFontOptions } from '../types'
 
 import { hash } from 'ohash'
 import { extractFontFaceData } from '../css/parse'
-import { $fetch } from '../fetch'
+import { fetchWithRetries } from '../fetch'
 import { cleanFontFaces, defineFontProvider, prepareWeights, splitCssIntoSubsets } from '../utils'
 
 type VariableAxis = 'opsz' | 'slnt' | 'wdth' | (string & {})
@@ -62,7 +62,7 @@ function getFallbacks(category: string): string[] | undefined {
 }
 
 export default defineFontProvider('google', async (providerOptions: GoogleProviderOptions, ctx) => {
-  const googleFonts = await ctx.storage.getItem('google:meta.json', () => $fetch<{ familyMetadataList: FontIndexMeta[] }>('https://fonts.google.com/metadata/fonts', { responseType: 'json' }).then(r => r.familyMetadataList))
+  const { familyMetadataList: googleFonts } = await ctx.storage.getItem('google:meta.json', () => fetchWithRetries('https://fonts.google.com/metadata/fonts').then(res => res.json() as Promise<{ familyMetadataList: FontIndexMeta[] }>))
 
   const styleMap = {
     italic: '1',
@@ -119,18 +119,15 @@ export default defineFontProvider('google', async (providerOptions: GoogleProvid
       if (!userAgent)
         continue
 
-      const rawCss = await $fetch<string>('/css2', {
-        baseURL: 'https://fonts.googleapis.com',
+      let url = `https://fonts.googleapis.com/css2?family=${font.family}:${resolvedAxes.join(',')}@${resolvedVariants.join(';')}`
+      if (glyphs) {
+        url += `&text=${encodeURIComponent(glyphs)}`
+      }
+      const rawCss = await fetchWithRetries(url, {
         headers: {
           'user-agent': userAgent,
         },
-        query: {
-          family: `${font.family}:${resolvedAxes.join(',')}@${resolvedVariants.join(
-            ';',
-          )}`,
-          ...(glyphs && { text: glyphs }),
-        },
-      })
+      }).then(res => res.text())
       const groups = splitCssIntoSubsets(rawCss).filter(group => group.subset ? options.subsets.includes(group.subset) : true)
       for (const group of groups) {
         const data = extractFontFaceData(group.css)

--- a/src/providers/googleicons.ts
+++ b/src/providers/googleicons.ts
@@ -1,7 +1,7 @@
 import type { ResolveFontOptions } from '../types'
 import { hash } from 'ohash'
 import { extractFontFaceData } from '../css/parse'
-import { $fetch } from '../fetch'
+import { fetchWithRetries } from '../fetch'
 import { cleanFontFaces, defineFontProvider } from '../utils'
 import { userAgents } from './google'
 
@@ -33,9 +33,9 @@ export interface GoogleiconsFamilyOptions {
 
 export default defineFontProvider('googleicons', async (providerOptions: GoogleiconsProviderOptions, ctx) => {
   const googleIcons = await ctx.storage.getItem('googleicons:meta.json', async () => {
-    const data = await $fetch<string>(
+    const data = await fetchWithRetries(
       'https://fonts.google.com/metadata/icons?key=material_symbols&incomplete=true',
-    )
+    ).then(res => res.text())
     const response: { families: string[] } = JSON.parse(
       data.substring(data.indexOf('\n') + 1), // remove the first line which makes it an invalid JSON
     )
@@ -56,24 +56,19 @@ export default defineFontProvider('googleicons', async (providerOptions: Googlei
 
       // Legacy Material Icons
       if (family.includes('Icons')) {
-        css += await $fetch<string>('/icon', {
-          baseURL: 'https://fonts.googleapis.com',
+        css += await fetchWithRetries(`https://fonts.googleapis.com/icon?family=${family}`, {
           headers: { 'user-agent': userAgent },
-          query: {
-            family,
-          },
-        })
+        }).then(res => res.text())
       }
       // New Material Symbols
       else {
-        css += await $fetch<string>('/css2', {
-          baseURL: 'https://fonts.googleapis.com',
+        let url = `https://fonts.googleapis.com/css2?family=${family}:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200`
+        if (iconNames) {
+          url += `&icon_names=${iconNames}`
+        }
+        css += await fetchWithRetries(url, {
           headers: { 'user-agent': userAgent },
-          query: {
-            family: `${family}:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200`,
-            ...(iconNames && { icon_names: iconNames }),
-          },
-        })
+        }).then(res => res.text())
       }
     }
 

--- a/src/providers/npm.ts
+++ b/src/providers/npm.ts
@@ -2,7 +2,7 @@ import type { FontFaceData, ResolveFontOptions } from '../types'
 
 import { hash } from 'ohash'
 import { extractFontFaceData } from '../css/parse'
-import { $fetch } from '../fetch'
+import { fetchWithRetries } from '../fetch'
 import { cleanFontFaces, defineFontProvider } from '../utils'
 
 export interface NpmProviderOptions {
@@ -138,7 +138,6 @@ interface DetectedFont {
 export default defineFontProvider('npm', (providerOptions: NpmProviderOptions, ctx) => {
   const cdn = providerOptions.cdn || DEFAULT_CDN
   const remote = providerOptions.remote ?? true
-  const npmFetch = $fetch.create({ baseURL: cdn })
   const readFile = providerOptions.readFile
   const root = providerOptions.root || '.'
 
@@ -263,7 +262,7 @@ export default defineFontProvider('npm', (providerOptions: NpmProviderOptions, c
   async function resolveFromCdn(pkgName: string, pkgVersion: string, cssFile: string, family: string, formats: ResolveFontOptions['formats']): Promise<FontFaceData[] | null> {
     let css: string | null
     try {
-      css = await npmFetch<string>(`${pkgName}@${pkgVersion}/${cssFile}`)
+      css = await fetchWithRetries(`${cdn}/${pkgName}@${pkgVersion}/${cssFile}`).then(res => res.text())
     }
     catch {
       return null

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1,28 +1,26 @@
-import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
-import { $fetch, mini$fetch } from '../src/fetch'
-import * as fetchModule from '../src/fetch'
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fetchWithRetries } from '../src/fetch'
 
 describe('unifont', () => {
   const originalFetch = globalThis.fetch
   beforeEach(() => {
+    vi.useFakeTimers()
     globalThis.fetch = vi.fn(() =>
       Promise.reject(new Error('Network Error')),
     )
-    vi.spyOn(fetchModule, 'mini$fetch')
+  })
+  afterEach(() => {
+    vi.useRealTimers()
   })
   afterAll(() => {
     globalThis.fetch = originalFetch
   })
-  it('does not mutate url', async () => {
-    const options = {
-      baseURL: 'https://fonts.googleapis.com',
-      headers: { 'user-agent': 'my-user-agent' },
-      query: {
-        family: `test`,
-      },
-    }
-    await $fetch('/css2', options).catch(() => null)
-    expect(mini$fetch).toHaveBeenCalledTimes(3)
-    expect(mini$fetch).toHaveBeenLastCalledWith('/css2', { ...options, retries: 0 })
+  it('retries the request before giving up', async () => {
+    const promise = fetchWithRetries('https://fonts.googleapis.com/css2?family=test', undefined, 2).catch(() => null)
+    await vi.runAllTimersAsync()
+    await promise
+    // 1 initial attempt + 2 retries
+    expect(globalThis.fetch).toHaveBeenCalledTimes(3)
+    expect(globalThis.fetch).toHaveBeenLastCalledWith('https://fonts.googleapis.com/css2?family=test', undefined)
   })
 })

--- a/test/providers/adobe.test.ts
+++ b/test/providers/adobe.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it, vi } from 'vitest'
 import { createUnifont, providers } from '../../src'
 import { mockFetchReturn, pickUniqueBy, sanitizeFontSource } from '../utils'
 
-// Disable $fetch retry logic
+// Disable fetch retry logic
 await vi.hoisted(async () => {
-  const { disable$fetchRetry } = await import('../utils')
-  await disable$fetchRetry()
+  const { disableFetchRetry } = await import('../utils')
+  await disableFetchRetry()
 })
 
 describe('adobe', () => {

--- a/test/providers/fontsource.test.ts
+++ b/test/providers/fontsource.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it, vi } from 'vitest'
 import { createUnifont, providers } from '../../src'
 import { mockFetchReturn } from '../utils'
 
-// Disable $fetch retry logic
+// Disable fetch retry logic
 await vi.hoisted(async () => {
-  const { disable$fetchRetry } = await import('../utils')
-  await disable$fetchRetry()
+  const { disableFetchRetry } = await import('../utils')
+  await disableFetchRetry()
 })
 
 describe('fontsource', () => {

--- a/test/providers/npm.test.ts
+++ b/test/providers/npm.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it, vi } from 'vitest'
 import { createUnifont, providers } from '../../src'
 import { mockFetchReturn } from '../utils'
 
-// Disable $fetch retry logic
+// Disable fetch retry logic
 await vi.hoisted(async () => {
-  const { disable$fetchRetry } = await import('../utils')
-  await disable$fetchRetry()
+  const { disableFetchRetry } = await import('../utils')
+  await disableFetchRetry()
 })
 
 // Minimal CSS fixture that matches real fontsource structure

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -65,17 +65,12 @@ export function mockFetchReturn(condition: RegExp, value: () => unknown) {
   }
 }
 
-export async function disable$fetchRetry() {
+export async function disableFetchRetry() {
   vi.mock('../../src/fetch', async (importOriginal) => {
     const mod = await importOriginal<typeof import('../../src/fetch')>()
     return {
-      $fetch: Object.assign(mod.mini$fetch, {
-        create: (defaults?: any) => (url: string, options?: any) => mod.mini$fetch(url, {
-          ...defaults,
-          ...options,
-          retries: 0, // Disable retries
-        }),
-      }),
+      // Disable retries
+      fetchWithRetries: (url: string, init?: RequestInit) => mod.fetchWithRetries(url, init, 0),
     }
   })
 }


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

<img width="1609" height="314" alt="image" src="https://github.com/user-attachments/assets/ceaa2790-f2ef-4b6b-986f-3cd9c864cf46" />

Ofetch is pretty heavy for what we use it for so I replaced it with a simpler fetch based helper function. Achieves the same but much smaller.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked network fetching across font providers to use a unified retry-enabled helper, with consistent handling of non-success HTTP responses and improved behavior for transient failures (including rate-limited requests).
* **Dependencies**
  * Removed the external `ofetch` dependency.
* **Tests**
  * Updated tests and test utilities to mock and verify the new retry logic deterministically, including renaming the retry-disable helper to match the new fetch implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->