### PR TITLE
fix!: only request range endpoints when falling back to static weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,8 @@ const { fonts } = await unifont.resolveFont('Poppins', {
 })
 ```
 
+If the family has no variable font covering the requested range, the range falls back to the closest available static weight at each end of the range (so `500 900` resolves to two faces, not every published weight in between). List the weights explicitly if you need the intermediate ones.
+
 ###### `styles`
 
 - Type: `('normal' | 'italic' | 'oblique')[]`

--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ const { fonts } = await unifont.resolveFont('Poppins', {
 })
 ```
 
-If the family has no variable font covering the requested range, the range resolves to the closest available weights inside it: each endpoint, plus the weight nearest to `400` so that default-weight text still matches sensibly. So `500 900` resolves to two faces rather than every published weight in between. List the weights explicitly if you need the intermediate ones.
+If the family has no variable font covering the requested range, the range resolves to representative static weights: the available weights at each end of the range, plus the one nearest to `400` so that default-weight text still matches sensibly. So `500 900` resolves to two faces rather than every published weight in between. If no available weight falls inside the range at all (say `450 480` when only `400` and `500` are published), the closest available weight is used instead. List the weights explicitly if you need the intermediate ones.
 
 ###### `styles`
 

--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ const { fonts } = await unifont.resolveFont('Poppins', {
 })
 ```
 
-If the family has no variable font covering the requested range, the range falls back to the closest available static weight at each end of the range (so `500 900` resolves to two faces, not every published weight in between). List the weights explicitly if you need the intermediate ones.
+If the family has no variable font covering the requested range, the range resolves to the closest available weights inside it: each endpoint, plus the weight nearest to `400` so that default-weight text still matches sensibly. So `500 900` resolves to two faces rather than every published weight in between. List the weights explicitly if you need the intermediate ones.
 
 ###### `styles`
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,16 +38,18 @@ export function prepareWeights({
         collectedWeights.push(weight)
         continue
       }
-      // As a fallback, request all weights in between
+      // A variable font serves the whole range from one file, but a static family needs one
+      // file per weight, so we only fall back to the endpoints of the range rather than
+      // downloading every intermediate weight the family happens to publish.
       const [min, max] = weight.split(' ')
-      collectedWeights.push(
-        ...weights
-          .filter((_w) => {
-            const w = Number(_w)
-            return w >= Number(min) && w <= Number(max)
-          })
-          .map(w => String(w)),
-      )
+      const inRange = weights
+        .map(Number)
+        .filter(w => w >= Number(min) && w <= Number(max))
+        .sort((a, b) => a - b)
+
+      if (inRange.length > 0) {
+        collectedWeights.push(String(inRange[0]), String(inRange.at(-1)))
+      }
       continue
     }
     // The requested weight is a standard weight

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,17 +38,25 @@ export function prepareWeights({
         collectedWeights.push(weight)
         continue
       }
-      // A variable font serves the whole range from one file, but a static family needs one
-      // file per weight, so we only fall back to the endpoints of the range rather than
-      // downloading every intermediate weight the family happens to publish.
+      // A static family needs one file per weight, so we resolve a range to a handful of
+      // representative weights rather than every weight the family happens to publish.
       const [min, max] = weight.split(' ')
-      const inRange = weights
+      const available = weights
         .map(Number)
-        .filter(w => w >= Number(min) && w <= Number(max))
+        .filter(w => !Number.isNaN(w))
         .sort((a, b) => a - b)
+      const inRange = available.filter(w => w >= Number(min) && w <= Number(max))
 
       if (inRange.length > 0) {
-        collectedWeights.push(String(inRange[0]), String(inRange.at(-1)))
+        // Keeping the weight nearest to `normal` as well as the endpoints means text at the
+        // default weight is never matched against a far-away weight by the browser's
+        // font matching algorithm (which would render, say, 400 as 100).
+        for (const w of [inRange[0]!, closestTo(inRange, 400), inRange.at(-1)!]) {
+          collectedWeights.push(String(w))
+        }
+      }
+      else if (available.length > 0) {
+        collectedWeights.push(String(closestTo(available, clamp(400, Number(min), Number(max)))))
       }
       continue
     }
@@ -62,6 +70,21 @@ export function prepareWeights({
     weight,
     variable: weight.includes(' '),
   }))
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max)
+}
+
+/** Picks the value nearest to `target`, preferring the lower value when two are equidistant. */
+function closestTo(sortedValues: number[], target: number): number {
+  let closest = sortedValues[0]!
+  for (const value of sortedValues) {
+    if (Math.abs(value - target) < Math.abs(closest - target)) {
+      closest = value
+    }
+  }
+  return closest
 }
 
 export function splitCssIntoSubsets(input: string): { subset: string | null, css: string }[] {

--- a/test/providers/google.test.ts
+++ b/test/providers/google.test.ts
@@ -227,12 +227,12 @@ describe('google', () => {
     expect(fonts.length).toEqual(2)
   })
 
-  it('falls back to static weights', async () => {
+  it('falls back to the endpoints of the range for static families', async () => {
     const unifont = await createUnifont([providers.google()])
     const { fonts } = await unifont.resolveFont('Lato', {
       weights: ['400 1100'],
     })
-    expect(fonts.length).toBe(12)
+    expect(pickUniqueBy(fonts, fnt => String(fnt.weight)).sort()).toEqual(['400', '900'])
   })
 
   describe('formats', () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -19,7 +19,7 @@ describe('utils', () => {
       })).toEqual([])
     })
 
-    it('returns standard weights as fallbacks for a variable font if available', () => {
+    it('returns only the range endpoints as fallbacks for a static family', () => {
       expect(
         prepareWeights({
           inputWeights: ['400 600'],
@@ -28,8 +28,32 @@ describe('utils', () => {
         }),
       ).toEqual([
         { weight: '400', variable: false },
-        { weight: '500', variable: false },
         { weight: '600', variable: false },
+      ])
+    })
+
+    it('clamps range endpoints to the closest available static weights', () => {
+      expect(
+        prepareWeights({
+          inputWeights: ['100 900'],
+          hasVariableWeights: false,
+          weights: ['700', '400', '500'],
+        }),
+      ).toEqual([
+        { weight: '400', variable: false },
+        { weight: '700', variable: false },
+      ])
+    })
+
+    it('returns a single weight when only one is available in the range', () => {
+      expect(
+        prepareWeights({
+          inputWeights: ['400 700'],
+          hasVariableWeights: false,
+          weights: ['300', '500'],
+        }),
+      ).toEqual([
+        { weight: '500', variable: false },
       ])
     })
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -19,16 +19,30 @@ describe('utils', () => {
       })).toEqual([])
     })
 
-    it('returns only the range endpoints as fallbacks for a static family', () => {
+    it('returns the range endpoints as fallbacks for a static family', () => {
       expect(
         prepareWeights({
-          inputWeights: ['400 600'],
+          inputWeights: ['500 700'],
           hasVariableWeights: false,
           weights: ['300', '400', '500', '600', '700'],
         }),
       ).toEqual([
+        { weight: '500', variable: false },
+        { weight: '700', variable: false },
+      ])
+    })
+
+    it('keeps the weight nearest to 400 as well as the range endpoints', () => {
+      expect(
+        prepareWeights({
+          inputWeights: ['100 900'],
+          hasVariableWeights: false,
+          weights: ['100', '300', '400', '700', '900'],
+        }),
+      ).toEqual([
+        { weight: '100', variable: false },
         { weight: '400', variable: false },
-        { weight: '600', variable: false },
+        { weight: '900', variable: false },
       ])
     })
 
@@ -42,6 +56,18 @@ describe('utils', () => {
       ).toEqual([
         { weight: '400', variable: false },
         { weight: '700', variable: false },
+      ])
+    })
+
+    it('falls back to the nearest weight outside the range when none is inside it', () => {
+      expect(
+        prepareWeights({
+          inputWeights: ['450 480'],
+          hasVariableWeights: false,
+          weights: ['400', '500'],
+        }),
+      ).toEqual([
+        { weight: '400', variable: false },
       ])
     })
 


### PR DESCRIPTION
passing a range can seriously impact performance when there is no variable font available - this is an approach to try to cut down on that by just resolving the two weights on either end of the range.

it's a breaking change, and I'd value feedback or thoughts before I merge it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved static font weight range handling.
  * Requested ranges now select representative available weights at the lower and upper bounds, plus the weight nearest to 400 when applicable.
  * Ranges are clamped to supported weights, with sensible fallback selection when no weights fall within the requested range.
  * Variable font ranges continue to be preserved as a single range.

* **Documentation**
  * Clarified fallback behavior for unsupported variable weight ranges, including range endpoints and the weight nearest to 400.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->