### PR TITLE
fix(google): pin axes to valid ranges + avoid pinning to default value

### DIFF
--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -153,6 +153,10 @@ export default defineFontProvider('google', async (providerOptions: GoogleProvid
       for (const group of groups) {
         const data = extractFontFaceData(group.css)
         data.map((f) => {
+          // avoid accidental pinning to a single width
+          if (!resolvedVariableAxes.wdth && f.stretch && !f.stretch.includes(' ')) {
+            delete f.stretch
+          }
           f.meta ??= {}
           f.meta.priority = priority
           if (group.subset) {

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -202,14 +202,14 @@ interface FontAxis {
 function clampAxisValue(value: string | [string, string], axis: FontAxis): string | undefined {
   if (!Array.isArray(value)) {
     const parsed = Number(value)
-    if (Number.isNaN(parsed))
+    if (!Number.isFinite(parsed))
       return undefined
     return String(clamp(parsed, axis))
   }
 
   const min = Number(value[0])
   const max = Number(value[1])
-  if (Number.isNaN(min) || Number.isNaN(max))
+  if (!Number.isFinite(min) || !Number.isFinite(max) || min > max)
     return undefined
 
   // The requested range does not overlap the axis at all

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -73,34 +73,55 @@ export default defineFontProvider('google', async (providerOptions: GoogleProvid
   async function getFontDetails(font: FontIndexMeta, options: ResolveFontOptions<GoogleFamilyOptions>) {
     const styles = [...new Set(options.styles.map(i => styleMap[i]))].sort()
     const glyphs = (options.options?.experimental?.glyphs ?? providerOptions.experimental?.glyphs?.[font.family])?.join('')
-    const weights = prepareWeights({
+    // The `css2` endpoint instances the font down to the axes named in the request:
+    // any axis we omit is stripped from the delivered file, and any value outside a
+    // family's real axis range is a hard 400 rather than a partial result. So every
+    // requested axis value is clamped against the axis metadata before we build the URL.
+    const fontAxes = new Map(font.axes.map(axis => [axis.tag, axis]))
+    const weightAxis = fontAxes.get('wght')
+
+    const weights = dedupeBy(prepareWeights({
       inputWeights: options.weights,
-      hasVariableWeights: font.axes.some(a => a.tag === 'wght'),
+      hasVariableWeights: !!weightAxis,
       weights: Object.keys(font.fonts),
-    }).map(v => v.variable
-      ? ({
-          weight: v.weight.replace(' ', '..'),
-          variable: v.variable,
-        })
-      : v)
+    }).flatMap((v) => {
+      if (!v.variable)
+        return v
+      const [min, max] = v.weight.split(' ') as [string, string]
+      const clamped = clampAxisValue([min, max], weightAxis!)
+      if (!clamped)
+        return []
+      return { weight: clamped, variable: clamped.includes('..') }
+    }), v => v.weight)
 
     if (weights.length === 0 || styles.length === 0)
       return []
 
+    const variableAxis = options.options?.experimental?.variableAxis ?? providerOptions.experimental?.variableAxis?.[font.family]
+    const resolvedVariableAxes: Record<string, string[]> = {}
+    for (const [tag, values] of Object.entries(variableAxis ?? {})) {
+      const axis = fontAxes.get(tag)
+      if (!axis || !values)
+        continue
+      const resolved = [...new Set(values.flatMap(value => clampAxisValue(value, axis) ?? []))]
+      if (resolved.length > 0) {
+        resolvedVariableAxes[tag] = resolved
+      }
+    }
+
     const resolvedAxes = []
     let resolvedVariants: string[] = []
-    const variableAxis = options.options?.experimental?.variableAxis ?? providerOptions.experimental?.variableAxis?.[font.family]
     const candidateAxes = [
       'wght',
       'ital',
-      ...Object.keys(variableAxis ?? {}),
+      ...Object.keys(resolvedVariableAxes),
     ].sort(googleFlavoredSorting)
 
     for (const axis of candidateAxes) {
       const axisValue = ({
         wght: weights.map(v => v.weight),
         ital: styles,
-      })[axis] ?? variableAxis![axis]!.map(v => Array.isArray(v) ? `${v[0]}..${v[1]}` : v)
+      })[axis] ?? resolvedVariableAxes[axis]!
 
       if (resolvedVariants.length === 0) {
         resolvedVariants = axisValue
@@ -167,6 +188,48 @@ export default defineFontProvider('google', async (providerOptions: GoogleProvid
 
 /** internal */
 
+interface FontAxis {
+  tag: string
+  min: number
+  max: number
+  defaultValue: number
+}
+
+function clampAxisValue(value: string | [string, string], axis: FontAxis): string | undefined {
+  if (!Array.isArray(value)) {
+    const parsed = Number(value)
+    if (Number.isNaN(parsed))
+      return undefined
+    return String(clamp(parsed, axis))
+  }
+
+  const min = Number(value[0])
+  const max = Number(value[1])
+  if (Number.isNaN(min) || Number.isNaN(max))
+    return undefined
+
+  // The requested range does not overlap the axis at all
+  if (max < axis.min || min > axis.max)
+    return undefined
+
+  const clampedMin = clamp(min, axis)
+  const clampedMax = clamp(max, axis)
+
+  return clampedMin === clampedMax ? String(clampedMin) : `${clampedMin}..${clampedMax}`
+}
+
+function clamp(value: number, axis: FontAxis) {
+  return Math.min(Math.max(value, axis.min), axis.max)
+}
+
+function dedupeBy<T>(items: T[], by: (item: T) => string): T[] {
+  const seen = new Set<string>()
+  return items.filter((item) => {
+    const key = by(item)
+    return !seen.has(key) && !!seen.add(key)
+  })
+}
+
 interface FontIndexMeta {
   family: string
   subsets: string[]
@@ -177,12 +240,7 @@ interface FontIndexMeta {
     width: number | null
     lineHeight: number | null
   }>
-  axes: Array<{
-    tag: string
-    min: number
-    max: number
-    defaultValue: number
-  }>
+  axes: FontAxis[]
 }
 
 // Google wants lowercase letters to be in front of uppercase letters.

--- a/test/providers/google.test.ts
+++ b/test/providers/google.test.ts
@@ -312,7 +312,6 @@ describe('google', () => {
           variableAxis: {
             'Noto Sans': {
               wdth: [['62', '100']],
-              // @ts-expect-error Noto Sans has no `slnt` axis
               slnt: [['-15', '0']],
             },
           },
@@ -325,6 +324,26 @@ describe('google', () => {
       })
 
       expect(requests).toHaveBeenCalledWith('https://fonts.googleapis.com/css2?family=Noto Sans:ital,wdth,wght@0,62.5..100,400')
+      restore()
+    })
+
+    it('drops a descending range', async () => {
+      const { requests, restore } = mockCss2()
+      const unifont = await createUnifont([providers.google()])
+      await unifont.resolveFont('Archivo', {
+        formats: ['woff2'],
+        styles: ['normal'],
+        weights: ['400'],
+        options: {
+          google: {
+            experimental: {
+              variableAxis: { wdth: [['125', '62']] },
+            },
+          },
+        },
+      })
+
+      expect(requests).toHaveBeenCalledWith('https://fonts.googleapis.com/css2?family=Archivo:ital,wght@0,400')
       restore()
     })
 

--- a/test/providers/google.test.ts
+++ b/test/providers/google.test.ts
@@ -1,7 +1,36 @@
 import type { ResolveFontOptions } from '../../src'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { createUnifont, providers } from '../../src'
-import { getOptimizerIdentityFromUrl, groupBy, pickUniqueBy } from '../utils'
+import { getOptimizerIdentityFromUrl, groupBy, mockFetchReturn, pickUniqueBy } from '../utils'
+
+const MOCK_CSS = `/* latin */
+@font-face {
+  font-family: 'Mock';
+  font-style: normal;
+  font-weight: 100 700;
+  font-stretch: 100%;
+  src: url(https://fonts.gstatic.com/s/mock/v1/mock.woff2) format('woff2');
+  unicode-range: U+0000-00FF;
+}`
+
+function mockCss2(css = MOCK_CSS) {
+  const requests = vi.fn()
+  const restore = mockFetchReturn(/fonts\.googleapis\.com\/css2/, () => new Response(css))
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (...args: Parameters<typeof fetch>) => {
+    if (/fonts\.googleapis\.com\/css2/.test(args[0] as string)) {
+      requests(decodeURIComponent(args[0] as string))
+    }
+    return originalFetch(...args)
+  }
+  return {
+    requests,
+    restore: () => {
+      globalThis.fetch = originalFetch
+      restore()
+    },
+  }
+}
 
 describe('google', () => {
   it('correctly types options', async () => {
@@ -233,6 +262,91 @@ describe('google', () => {
       weights: ['400 1100'],
     })
     expect(fonts.length).toBe(12)
+  })
+
+  describe('axis clamping', () => {
+    it('clamps a variable weight range to the axis range', async () => {
+      const { requests, restore } = mockCss2()
+      const unifont = await createUnifont([providers.google()])
+      await unifont.resolveFont('IBM Plex Sans', {
+        formats: ['woff2'],
+        styles: ['normal'],
+        weights: ['100 900'],
+      })
+
+      expect(requests).toHaveBeenCalledWith('https://fonts.googleapis.com/css2?family=IBM Plex Sans:ital,wght@0,100..700')
+      restore()
+    })
+
+    it('collapses a range that only touches the axis to a static value', async () => {
+      const { requests, restore } = mockCss2()
+      const unifont = await createUnifont([providers.google()])
+      await unifont.resolveFont('IBM Plex Sans', {
+        formats: ['woff2'],
+        styles: ['normal'],
+        weights: ['700 1000'],
+      })
+
+      expect(requests).toHaveBeenCalledWith('https://fonts.googleapis.com/css2?family=IBM Plex Sans:ital,wght@0,700')
+      restore()
+    })
+
+    it('drops a weight range that does not overlap the axis', async () => {
+      const { requests, restore } = mockCss2()
+      const unifont = await createUnifont([providers.google()])
+      const { fonts } = await unifont.resolveFont('IBM Plex Sans', {
+        formats: ['woff2'],
+        styles: ['normal'],
+        weights: ['800 1000'],
+      })
+
+      expect(fonts).toStrictEqual([])
+      expect(requests).not.toHaveBeenCalled()
+      restore()
+    })
+
+    it('clamps variable axis values and drops unknown axes', async () => {
+      const { requests, restore } = mockCss2()
+      const unifont = await createUnifont([providers.google({
+        experimental: {
+          variableAxis: {
+            'Noto Sans': {
+              wdth: [['62', '100']],
+              // @ts-expect-error Noto Sans has no `slnt` axis
+              slnt: [['-15', '0']],
+            },
+          },
+        },
+      })])
+      await unifont.resolveFont('Noto Sans', {
+        formats: ['woff2'],
+        styles: ['normal'],
+        weights: ['400'],
+      })
+
+      expect(requests).toHaveBeenCalledWith('https://fonts.googleapis.com/css2?family=Noto Sans:ital,wdth,wght@0,62.5..100,400')
+      restore()
+    })
+
+    it('leaves in-range variable axis values untouched', async () => {
+      const { requests, restore } = mockCss2()
+      const unifont = await createUnifont([providers.google()])
+      await unifont.resolveFont('Archivo', {
+        formats: ['woff2'],
+        styles: ['normal'],
+        weights: ['100 900'],
+        options: {
+          google: {
+            experimental: {
+              variableAxis: { wdth: [['62', '125']] },
+            },
+          },
+        },
+      })
+
+      expect(requests).toHaveBeenCalledWith('https://fonts.googleapis.com/css2?family=Archivo:ital,wdth,wght@0,62..125,100..900')
+      restore()
+    })
   })
 
   describe('formats', () => {

--- a/test/providers/google.test.ts
+++ b/test/providers/google.test.ts
@@ -349,6 +349,41 @@ describe('google', () => {
     })
   })
 
+  describe('font-stretch', () => {
+    it('omits a single-value font-stretch when no width axis was requested', async () => {
+      const { restore } = mockCss2()
+      const unifont = await createUnifont([providers.google()])
+      const { fonts } = await unifont.resolveFont('Noto Sans', {
+        formats: ['woff2'],
+        styles: ['normal'],
+        weights: ['400'],
+      })
+
+      expect(fonts.every(font => font.stretch === undefined)).toBe(true)
+      restore()
+    })
+
+    it('keeps font-stretch when a width axis was requested', async () => {
+      const { restore } = mockCss2(MOCK_CSS.replace('100%', '62.5% 100%'))
+      const unifont = await createUnifont([providers.google()])
+      const { fonts } = await unifont.resolveFont('Noto Sans', {
+        formats: ['woff2'],
+        styles: ['normal'],
+        weights: ['400'],
+        options: {
+          google: {
+            experimental: {
+              variableAxis: { wdth: [['62', '100']] },
+            },
+          },
+        },
+      })
+
+      expect(fonts.map(font => font.stretch)).toStrictEqual(['62.5% 100%'])
+      restore()
+    })
+  })
+
   describe('formats', () => {
     it('woff2', async () => {
       const unifont = await createUnifont([providers.google()])

--- a/test/providers/google.test.ts
+++ b/test/providers/google.test.ts
@@ -327,6 +327,39 @@ describe('google', () => {
       restore()
     })
 
+    it('clamps a single axis value into range and drops non-numeric ones', async () => {
+      const { requests, restore } = mockCss2()
+      const unifont = await createUnifont([providers.google()])
+      await unifont.resolveFont('Archivo', {
+        formats: ['woff2'],
+        styles: ['normal'],
+        weights: ['400'],
+        options: {
+          google: {
+            experimental: {
+              variableAxis: { wdth: ['200', 'not-a-number'] },
+            },
+          },
+        },
+      })
+
+      expect(requests).toHaveBeenCalledWith('https://fonts.googleapis.com/css2?family=Archivo:ital,wdth,wght@0,125,400')
+      restore()
+    })
+
+    it('dedupes weight ranges that clamp onto the same value', async () => {
+      const { requests, restore } = mockCss2()
+      const unifont = await createUnifont([providers.google()])
+      await unifont.resolveFont('IBM Plex Sans', {
+        formats: ['woff2'],
+        styles: ['normal'],
+        weights: ['700 800', '700 1000'],
+      })
+
+      expect(requests).toHaveBeenCalledWith('https://fonts.googleapis.com/css2?family=IBM Plex Sans:ital,wght@0,700')
+      restore()
+    })
+
     it('drops a descending range', async () => {
       const { requests, restore } = mockCss2()
       const unifont = await createUnifont([providers.google()])


### PR DESCRIPTION
resolves https://github.com/nuxt/fonts/issues/731
resolves https://github.com/nuxt/fonts/issues/578

the issue here is that a fairly reasonable google config currently ends up with zero faces and this kind of warning:

```
Could not produce font face declaration for "IBM Plex Sans"
```

that's because something like `https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,100..900` gives a 400 response. (it only supports 100..700, not 100..900.)

but we already have everything needed to avoid this: the family metadata we fetch for `listFonts` carries `axes` with `min`/`max`/`defaultValue`

so the first commit clamps each requested value against the real axis before building the url

second, if you don't request a specific axis, it's _removed_ from the file, so because we pass google's `font-stretch: 100%` through since #345, it ends up getting _pinned_ to `wdth: 100`...

so we now drop a single-value `font-stretch` when no `wdth` was requested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Fonts handling by clamping variable font weights and axes to supported ranges.
  * Removed invalid or unsupported axis values before requesting fonts.
  * Prevented unnecessary fixed-width styling when no width axis is selected.
  * Reduced duplicate font-axis requests and avoided invalid font loading responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->