### PR TITLE
fix(npm): use fontsource entries correctly + don't emit cdn urls with `remote: false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ providers.npm({ cdn: 'https://esm.sh' })
 - Type: `boolean`
 - Default: `true`
 
-Whether to fall back to fetching from the CDN when local resolution fails. Set to `false` to only resolve from locally installed packages:
+Whether to fall back to fetching from the CDN when local resolution fails. Set to `false` to only resolve from locally installed packages, in which case font sources are emitted as `file://` URLs pointing into `node_modules` and no CDN request is made:
 
 ```js
 import { providers } from 'unifont'

--- a/README.md
+++ b/README.md
@@ -396,9 +396,9 @@ const { fonts } = await unifont.resolveFont('Roboto', {
 ##### `file`
 
 - Type: `string`
-- Default: `'index.css'`
+- Default: per-weight/per-style entry points, falling back to `'index.css'`
 
-The entry CSS file to parse from the package:
+The entry CSS file to parse from the package. When not set, `@fontsource/*` packages are resolved through their per-weight and per-style entry points (`<weight>.css`, `<weight>-italic.css`) for the requested weights and styles:
 
 ```js
 import { createUnifont, providers } from 'unifont'

--- a/src/providers/npm.ts
+++ b/src/providers/npm.ts
@@ -277,11 +277,6 @@ export default defineFontProvider('npm', (providerOptions: NpmProviderOptions, c
     const resolved: FontFaceData[] = []
 
     for (const face of fontFaces) {
-      if (!Array.isArray(face.src)) {
-        resolved.push(face)
-        continue
-      }
-
       const src: FontFaceData['src'] = []
       for (const source of face.src) {
         if (!('url' in source)) {

--- a/src/providers/npm.ts
+++ b/src/providers/npm.ts
@@ -60,7 +60,10 @@ export interface NpmFamilyOptions {
   version?: string
   /**
    * The entry CSS file to parse from the package.
-   * @default 'index.css'
+   *
+   * When not specified, per-weight and per-style entry points
+   * (`<weight>.css`, `<weight>-italic.css`) are resolved for the requested
+   * weights and styles, falling back to `index.css`.
    */
   file?: string
 }
@@ -119,20 +122,59 @@ function familyToSlug(family: string): string {
 const VARIABLE_RE = / Variable$/
 
 /**
- * Guess the npm package name and CSS file for a font family that wasn't
- * found in the auto-detected packages. Uses fontsource conventions as fallback.
+ * Guess the npm package name for a font family that wasn't found in the
+ * auto-detected packages. Uses fontsource conventions as fallback.
  */
-function guessPackageForFamily(family: string): { pkgName: string, file: string } {
+function guessPackageForFamily(family: string): string {
   if (family.endsWith(' Variable')) {
-    return { pkgName: `@fontsource-variable/${familyToSlug(family.replace(VARIABLE_RE, ''))}`, file: 'index.css' }
+    return `@fontsource-variable/${familyToSlug(family.replace(VARIABLE_RE, ''))}`
   }
-  return { pkgName: `@fontsource/${familyToSlug(family)}`, file: 'index.css' }
+  return `@fontsource/${familyToSlug(family)}`
+}
+
+const DEFAULT_CSS_FILE = 'index.css'
+const STANDARD_WEIGHTS = ['100', '200', '300', '400', '500', '600', '700', '800', '900']
+
+/**
+ * `@fontsource/*` packages ship `index.css` with a single weight (400) alongside
+ * per-weight and per-style entry points, so the requested weights and styles are
+ * mapped onto those entry points. Other layouts (including
+ * `@fontsource-variable/*`, whose `index.css` covers the full weight range) use
+ * `index.css`.
+ */
+function resolveCssFiles(pkgName: string, options: Pick<ResolveFontOptions, 'weights' | 'styles'>): string[] {
+  if (!pkgName.startsWith('@fontsource/')) {
+    return [DEFAULT_CSS_FILE]
+  }
+
+  const weights = new Set<string>()
+  for (const weight of options.weights) {
+    if (weight.includes(' ')) {
+      const [min, max] = weight.split(' ').map(Number)
+      for (const standardWeight of STANDARD_WEIGHTS) {
+        if (Number(standardWeight) >= min! && Number(standardWeight) <= max!) {
+          weights.add(standardWeight)
+        }
+      }
+      continue
+    }
+    weights.add(weight)
+  }
+
+  const files: string[] = []
+  for (const weight of weights) {
+    for (const style of options.styles) {
+      files.push(style === 'normal' ? `${weight}.css` : `${weight}-${style}.css`)
+    }
+  }
+
+  return files.length > 0 ? files : [DEFAULT_CSS_FILE]
 }
 
 interface DetectedFont {
   family: string
   pkgName: string
-  file: string
+  file?: string
 }
 
 export default defineFontProvider('npm', (providerOptions: NpmProviderOptions, ctx) => {
@@ -188,7 +230,7 @@ export default defineFontProvider('npm', (providerOptions: NpmProviderOptions, c
             detectedFonts.set(family.toLowerCase(), {
               family,
               pkgName: depName,
-              file: pattern.file || 'index.css',
+              file: pattern.file,
             })
             break
           }
@@ -222,18 +264,20 @@ export default defineFontProvider('npm', (providerOptions: NpmProviderOptions, c
     }
   }
 
-  async function resolveFromLocal(pkgName: string, cssFile: string, family: string, formats: ResolveFontOptions['formats']): Promise<FontFaceData[] | null> {
+  async function resolveFromLocal(pkgName: string, cssFiles: string[], family: string, formats: ResolveFontOptions['formats']): Promise<FontFaceData[] | null> {
     if (!readFile) {
       return null
     }
 
-    const cssPath = `${root}/node_modules/${pkgName}/${cssFile}`
-    const css = await readFile(cssPath).catch(() => null)
-    if (!css) {
-      return null
+    const stylesheets = await Promise.all(cssFiles.map(cssFile => readFile(`${root}/node_modules/${pkgName}/${cssFile}`).catch(() => null)))
+
+    const fontFaces: FontFaceData[] = []
+    for (const css of stylesheets) {
+      if (css) {
+        fontFaces.push(...extractFontFaceData(css, family))
+      }
     }
 
-    const fontFaces = extractFontFaceData(css, family)
     if (fontFaces.length === 0) {
       return null
     }
@@ -259,20 +303,20 @@ export default defineFontProvider('npm', (providerOptions: NpmProviderOptions, c
     return cleanFontFaces(fontFaces, formats)
   }
 
-  async function resolveFromCdn(pkgName: string, pkgVersion: string, cssFile: string, family: string, formats: ResolveFontOptions['formats']): Promise<FontFaceData[] | null> {
-    let css: string | null
-    try {
-      css = await fetchWithRetries(`${cdn}/${pkgName}@${pkgVersion}/${cssFile}`).then(res => res.text())
+  async function resolveFromCdn(pkgName: string, pkgVersion: string, cssFiles: string[], family: string, formats: ResolveFontOptions['formats']): Promise<FontFaceData[] | null> {
+    const stylesheets = await Promise.all(cssFiles.map(cssFile => fetchWithRetries(`${cdn}/${pkgName}@${pkgVersion}/${cssFile}`).then(res => res.text()).catch(() => null)))
+
+    const fontFaces: FontFaceData[] = []
+    for (const css of stylesheets) {
+      if (css) {
+        fontFaces.push(...extractFontFaceData(css, family))
+      }
     }
-    catch {
+
+    if (fontFaces.length === 0) {
       return null
     }
 
-    if (!css) {
-      return null
-    }
-
-    const fontFaces = extractFontFaceData(css, family)
     const baseUrl = `${cdn}/${pkgName}@${pkgVersion}/`
     resolveUrlsToAbsolute(fontFaces, baseUrl)
 
@@ -292,48 +336,48 @@ export default defineFontProvider('npm', (providerOptions: NpmProviderOptions, c
       const familyOptions = options.options || {} as NpmFamilyOptions
 
       let pkgName: string
-      let cssFile: string
-      let pkgVersion: string
+      let file: string | undefined
 
       if (familyOptions.package) {
         // Explicit package override
         pkgName = familyOptions.package
-        cssFile = familyOptions.file || 'index.css'
-        pkgVersion = familyOptions.version || 'latest'
+        file = familyOptions.file
       }
       else {
         // Check auto-detected fonts
         const fonts = await getDetectedFonts()
         const detected = fonts.get(family.toLowerCase())
-        if (detected) {
-          pkgName = detected.pkgName
-          cssFile = familyOptions.file || detected.file
-          pkgVersion = familyOptions.version || 'latest'
-        }
-        else {
-          // Guess package name using fontsource conventions
-          const guessed = guessPackageForFamily(family)
-          pkgName = guessed.pkgName
-          cssFile = familyOptions.file || guessed.file
-          pkgVersion = familyOptions.version || 'latest'
-        }
+        pkgName = detected?.pkgName ?? guessPackageForFamily(family)
+        file = familyOptions.file || detected?.file
       }
 
-      const key = `npm:${pkgName}/${cssFile}-${hash(options)}`
+      const pkgVersion = familyOptions.version || 'latest'
+      const cssFiles = file ? [file] : resolveCssFiles(pkgName, options)
+
+      const key = `npm:${pkgName}/${cssFiles.join(',')}-${hash(options)}`
 
       const fonts = await ctx.storage.getItem(key, async () => {
-        // Try local resolution first
-        const localResult = await resolveFromLocal(pkgName, cssFile, family, options.formats)
-        if (localResult) {
-          return localResult
+        const candidates = cssFiles.includes(DEFAULT_CSS_FILE) ? [cssFiles] : [cssFiles, [DEFAULT_CSS_FILE]]
+
+        for (const files of candidates) {
+          const localResult = await resolveFromLocal(pkgName, files, family, options.formats)
+          if (localResult) {
+            return localResult
+          }
         }
 
         if (!remote) {
           return null
         }
 
-        // Fall back to CDN
-        return await resolveFromCdn(pkgName, pkgVersion, cssFile, family, options.formats)
+        for (const files of candidates) {
+          const cdnResult = await resolveFromCdn(pkgName, pkgVersion, files, family, options.formats)
+          if (cdnResult) {
+            return cdnResult
+          }
+        }
+
+        return null
       })
 
       if (!fonts) {

--- a/src/providers/npm.ts
+++ b/src/providers/npm.ts
@@ -1,6 +1,9 @@
 import type { FontFaceData, ResolveFontOptions } from '../types'
 
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { hash } from 'ohash'
+
 import { extractFontFaceData } from '../css/parse'
 import { fetchWithRetries } from '../fetch'
 import { cleanFontFaces, defineFontProvider } from '../utils'
@@ -15,7 +18,8 @@ export interface NpmProviderOptions {
    * Whether to fall back to fetching from the CDN when local resolution
    * fails or `readFile` is not provided.
    *
-   * Set to `false` to only resolve from locally installed packages.
+   * Set to `false` to only resolve from locally installed packages, emitting
+   * `file://` URLs for font files found in `node_modules`.
    * This is useful when another provider (e.g. `fontsource`) already
    * handles CDN resolution.
    *
@@ -264,6 +268,51 @@ export default defineFontProvider('npm', (providerOptions: NpmProviderOptions, c
     }
   }
 
+  /**
+   * Rewrite relative URLs to `file://` URLs pointing at the installed package.
+   * Sources whose files are missing on disk are dropped rather than silently
+   * falling back to the CDN, which `remote: false` promises not to use.
+   */
+  async function resolveUrlsToLocalFiles(fontFaces: FontFaceData[], pkgDir: string): Promise<FontFaceData[]> {
+    const resolved: FontFaceData[] = []
+
+    for (const face of fontFaces) {
+      if (!Array.isArray(face.src)) {
+        resolved.push(face)
+        continue
+      }
+
+      const src: FontFaceData['src'] = []
+      for (const source of face.src) {
+        if (!('url' in source)) {
+          src.push(source)
+          continue
+        }
+
+        const url = source.url
+        if (url.startsWith('http') || url.startsWith('data:') || url.startsWith('//')) {
+          src.push(source)
+          continue
+        }
+
+        const filePath = resolve(pkgDir, url)
+        const exists = await readFile!(filePath).then(contents => contents !== null).catch(() => false)
+        if (!exists) {
+          console.warn(`Could not find \`${filePath}\` when resolving fonts locally. \`unifont\` will not include this font source.`)
+          continue
+        }
+
+        src.push({ ...source, url: pathToFileURL(filePath).href })
+      }
+
+      if (src.some(source => 'url' in source)) {
+        resolved.push({ ...face, src })
+      }
+    }
+
+    return resolved
+  }
+
   async function resolveFromLocal(pkgName: string, cssFiles: string[], family: string, formats: ResolveFontOptions['formats']): Promise<FontFaceData[] | null> {
     if (!readFile) {
       return null
@@ -280,6 +329,11 @@ export default defineFontProvider('npm', (providerOptions: NpmProviderOptions, c
 
     if (fontFaces.length === 0) {
       return null
+    }
+
+    if (!remote) {
+      const localFaces = await resolveUrlsToLocalFiles(fontFaces, `${root}/node_modules/${pkgName}`)
+      return localFaces.length > 0 ? cleanFontFaces(localFaces, formats) : null
     }
 
     // Resolve relative URLs to absolute CDN URLs using the installed version

--- a/test/providers/npm.test.ts
+++ b/test/providers/npm.test.ts
@@ -41,6 +41,19 @@ const MOCK_ROBOTO_CSS = `
 }
 `
 
+function mockWeightCss(weight: string, style: 'normal' | 'italic') {
+  return `
+@font-face {
+  font-family: 'Roboto';
+  font-style: ${style};
+  font-display: swap;
+  font-weight: ${weight};
+  src: url(./files/roboto-latin-${weight}-${style}.woff2) format('woff2');
+  unicode-range: U+0000-00FF;
+}
+`
+}
+
 const MOCK_MULTI_FAMILY_CSS = `
 @font-face {
   font-family: 'Roboto';
@@ -415,6 +428,83 @@ describe('npm', () => {
           }
         }
       }
+    })
+
+    it('resolves per-weight and per-style stylesheets', async () => {
+      const readFile = vi.fn(async (path: string) => {
+        if (path === './package.json')
+          return MOCK_PACKAGE_JSON
+        if (path === './node_modules/@fontsource/roboto/package.json')
+          return MOCK_PKG_VERSION_JSON
+        const match = /\/(\d+)(-italic)?\.css$/.exec(path)
+        if (match)
+          return mockWeightCss(match[1]!, match[2] ? 'italic' : 'normal')
+        return null
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile })])
+      const { fonts } = await unifont.resolveFont('Roboto', { weights: ['400', '700'] })
+
+      expect(fonts.map(f => `${f.weight}-${f.style}`).sort()).toStrictEqual([
+        '400-italic',
+        '400-normal',
+        '700-italic',
+        '700-normal',
+      ])
+      expect(readFile).not.toHaveBeenCalledWith('./node_modules/@fontsource/roboto/index.css')
+    })
+
+    it('expands weight ranges into per-weight stylesheets', async () => {
+      const readFile = vi.fn(async (path: string) => {
+        if (path === './package.json')
+          return MOCK_PACKAGE_JSON
+        if (path === './node_modules/@fontsource/roboto/package.json')
+          return MOCK_PKG_VERSION_JSON
+        const match = /\/(\d+)\.css$/.exec(path)
+        if (match)
+          return mockWeightCss(match[1]!, 'normal')
+        return null
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile })])
+      const { fonts } = await unifont.resolveFont('Roboto', { weights: ['400 700'], styles: ['normal'] })
+
+      expect(fonts.map(f => f.weight)).toStrictEqual([400, 500, 600, 700])
+    })
+
+    it('falls back to index.css when per-weight stylesheets are missing', async () => {
+      const readFile = vi.fn(async (path: string) => {
+        if (path === './package.json')
+          return MOCK_PACKAGE_JSON
+        if (path === './node_modules/cal-sans/index.css')
+          return MOCK_CAL_SANS_CSS
+        if (path === './node_modules/cal-sans/package.json')
+          return JSON.stringify({ version: '1.0.1' })
+        return null
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile, remote: false })])
+      const { fonts } = await unifont.resolveFont('Cal Sans', { weights: ['600'] })
+
+      expect(fonts.length).toBe(1)
+    })
+
+    it('uses index.css for variable packages', async () => {
+      const readFile = vi.fn(async (path: string) => {
+        if (path === './package.json')
+          return MOCK_PACKAGE_JSON
+        if (path === './node_modules/@fontsource-variable/inter/index.css')
+          return MOCK_INTER_VARIABLE_CSS
+        if (path === './node_modules/@fontsource-variable/inter/package.json')
+          return MOCK_PKG_VERSION_JSON
+        return null
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile, remote: false })])
+      const { fonts } = await unifont.resolveFont('Inter Variable', { weights: ['100 900'] })
+
+      expect(fonts.length).toBe(1)
+      expect(readFile).toHaveBeenCalledWith('./node_modules/@fontsource-variable/inter/index.css')
     })
 
     it('does not fall back to CDN when remote is false', async () => {

--- a/test/providers/npm.test.ts
+++ b/test/providers/npm.test.ts
@@ -80,6 +80,21 @@ const MOCK_CAL_SANS_CSS = `
 }
 `
 
+const MOCK_LOCAL_SOURCE_CSS = `
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Roboto'), url(./files/roboto-latin-400-normal.woff2) format('woff2');
+}
+@font-face {
+  font-family: 'Roboto';
+  font-style: italic;
+  font-weight: 400;
+  src: local('Roboto Italic');
+}
+`
+
 const MOCK_INTER_VARIABLE_CSS = `
 /* inter-latin-wght-normal */
 @font-face {
@@ -262,6 +277,39 @@ describe('npm', () => {
 
       expect(fonts.length).toBe(1)
       expect(fonts[0]!.src[0]).toHaveProperty('url', 'https://fonts.example.com/roboto.woff2')
+
+      restoreFetch()
+    })
+
+    it('preserves local() sources', async () => {
+      const restoreFetch = mockFetchReturn(/@fontsource\/roboto/, () =>
+        new Response(MOCK_LOCAL_SOURCE_CSS))
+
+      const unifont = await createUnifont([providers.npm()])
+      const { fonts } = await unifont.resolveFont('Roboto')
+
+      expect(fonts.length).toBe(2)
+      expect(fonts[0]!.src[0]).toStrictEqual({ name: 'Roboto' })
+      expect(fonts[1]!.src).toStrictEqual([{ name: 'Roboto Italic' }])
+
+      restoreFetch()
+    })
+
+    it('falls back to index.css when per-weight stylesheets are unavailable', async () => {
+      const requested: string[] = []
+      const restoreFetch = mockFetchReturn(/@fontsource\/roboto/, (input) => {
+        const url = String(input)
+        requested.push(url)
+        if (!url.endsWith('/index.css'))
+          throw new Error('Not found')
+        return new Response(MOCK_ROBOTO_CSS)
+      })
+
+      const unifont = await createUnifont([providers.npm()])
+      const { fonts } = await unifont.resolveFont('Roboto', { weights: ['700'], styles: ['normal'] })
+
+      expect(fonts.length).toBe(3)
+      expect(requested.map(url => url.split('/').pop())).toStrictEqual(['700.css', 'index.css'])
 
       restoreFetch()
     })
@@ -472,6 +520,41 @@ describe('npm', () => {
       expect(fonts.map(f => f.weight)).toStrictEqual([400, 500, 600, 700])
     })
 
+    it('falls back to index.css when no styles are requested', async () => {
+      const readFile = vi.fn(async (path: string) => {
+        if (path === './package.json')
+          return MOCK_PACKAGE_JSON
+        if (path === './node_modules/@fontsource/roboto/index.css')
+          return MOCK_ROBOTO_CSS
+        if (path.includes('/node_modules/@fontsource/roboto/files/'))
+          return 'binary'
+        return null
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile, remote: false })])
+      const { fonts } = await unifont.resolveFont('Roboto', { weights: ['400'], styles: [] })
+
+      expect(fonts.length).toBe(3)
+      expect(readFile).toHaveBeenCalledWith('./node_modules/@fontsource/roboto/index.css')
+    })
+
+    it('uses latest version when local package.json has no version', async () => {
+      const readFile = vi.fn(async (path: string) => {
+        if (path === './package.json')
+          return MOCK_PACKAGE_JSON
+        if (path === './node_modules/@fontsource/roboto/400.css')
+          return MOCK_ROBOTO_CSS
+        if (path === './node_modules/@fontsource/roboto/package.json')
+          return JSON.stringify({ name: '@fontsource/roboto' })
+        return null
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile })])
+      const { fonts } = await unifont.resolveFont('Roboto', { weights: ['400'], styles: ['normal'] })
+
+      expect(fonts[0]!.src[0]).toHaveProperty('url', expect.stringContaining('@fontsource/roboto@latest'))
+    })
+
     it('falls back to index.css when per-weight stylesheets are missing', async () => {
       const readFile = vi.fn(async (path: string) => {
         if (path === './package.json')
@@ -573,6 +656,73 @@ describe('npm', () => {
       warn.mockRestore()
     })
 
+    it('preserves data and protocol-relative URLs', async () => {
+      const cssWithInlineSources = `
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  src: url(data:font/woff2;base64,AAA) format('woff2'), url(//cdn.example.com/roboto.woff2) format('woff2');
+}
+`
+      const readFile = vi.fn(async (path: string) => {
+        if (path === '/my/project/package.json')
+          return MOCK_PACKAGE_JSON
+        if (path === '/my/project/node_modules/@fontsource/roboto/400.css')
+          return cssWithInlineSources
+        return null
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile, remote: false, root: '/my/project' })])
+      const { fonts } = await unifont.resolveFont('Roboto', { weights: ['400'], styles: ['normal'] })
+
+      expect(fonts[0]!.src).toStrictEqual([
+        { url: 'data:font/woff2;base64,AAA', format: 'woff2' },
+        { url: '//cdn.example.com/roboto.woff2', format: 'woff2' },
+      ])
+    })
+
+    it('keeps local() sources and drops faces left without a URL', async () => {
+      const readFile = vi.fn(async (path: string) => {
+        if (path === '/my/project/package.json')
+          return MOCK_PACKAGE_JSON
+        if (path === '/my/project/node_modules/@fontsource/roboto/400.css')
+          return MOCK_LOCAL_SOURCE_CSS
+        if (path.includes('/node_modules/@fontsource/roboto/files/'))
+          return 'binary'
+        return null
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile, remote: false, root: '/my/project' })])
+      const { fonts } = await unifont.resolveFont('Roboto', { weights: ['400'] })
+
+      expect(fonts.length).toBe(1)
+      expect(fonts[0]!.style).toBe('normal')
+      expect(fonts[0]!.src).toStrictEqual([
+        { name: 'Roboto' },
+        { url: 'file:///my/project/node_modules/@fontsource/roboto/files/roboto-latin-400-normal.woff2', format: 'woff2' },
+      ])
+    })
+
+    it('drops sources when the font file cannot be read', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const readFile = vi.fn(async (path: string) => {
+        if (path === '/my/project/package.json')
+          return MOCK_PACKAGE_JSON
+        if (path === '/my/project/node_modules/cal-sans/index.css')
+          return MOCK_CAL_SANS_CSS
+        throw new Error('Permission denied')
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile, remote: false, root: '/my/project' })])
+      const { fonts } = await unifont.resolveFont('Cal Sans', { weights: ['600'] })
+
+      expect(fonts).toStrictEqual([])
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('CalSans-SemiBold.woff2'))
+
+      warn.mockRestore()
+    })
+
     it('preserves absolute URLs', async () => {
       const cssWithAbsoluteUrl = `
 @font-face {
@@ -637,6 +787,44 @@ describe('npm', () => {
       const names = await unifont.listFonts()
 
       expect(names).toBeUndefined()
+    })
+
+    it('returns undefined when package.json cannot be read', async () => {
+      const readFile = vi.fn(async () => {
+        throw new Error('Permission denied')
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile })])
+
+      expect(await unifont.listFonts()).toBeUndefined()
+    })
+
+    it('returns undefined when package.json is empty', async () => {
+      const readFile = vi.fn(async () => '')
+
+      const unifont = await createUnifont([providers.npm({ readFile })])
+
+      expect(await unifont.listFonts()).toBeUndefined()
+    })
+
+    it('returns undefined when package.json is not valid JSON', async () => {
+      const readFile = vi.fn(async (path: string) => path === './package.json' ? '{ not json' : null)
+
+      const unifont = await createUnifont([providers.npm({ readFile })])
+
+      expect(await unifont.listFonts()).toBeUndefined()
+    })
+
+    it('does not re-scan package.json when its content is unchanged', async () => {
+      const readFile = vi.fn(async (path: string) => path === './package.json' ? MOCK_PACKAGE_JSON : null)
+
+      const unifont = await createUnifont([providers.npm({ readFile, remote: false })])
+
+      const names1 = await unifont.listFonts()
+      const names2 = await unifont.listFonts()
+
+      expect(names2).toStrictEqual(names1)
+      expect(readFile.mock.calls.filter(([path]) => path === './package.json').length).toBe(2)
     })
 
     it('lazily reads package.json on first call', async () => {

--- a/test/providers/npm.test.ts
+++ b/test/providers/npm.test.ts
@@ -478,8 +478,8 @@ describe('npm', () => {
           return MOCK_PACKAGE_JSON
         if (path === './node_modules/cal-sans/index.css')
           return MOCK_CAL_SANS_CSS
-        if (path === './node_modules/cal-sans/package.json')
-          return JSON.stringify({ version: '1.0.1' })
+        if (path.includes('/node_modules/cal-sans/fonts/'))
+          return 'binary'
         return null
       })
 
@@ -495,8 +495,8 @@ describe('npm', () => {
           return MOCK_PACKAGE_JSON
         if (path === './node_modules/@fontsource-variable/inter/index.css')
           return MOCK_INTER_VARIABLE_CSS
-        if (path === './node_modules/@fontsource-variable/inter/package.json')
-          return MOCK_PKG_VERSION_JSON
+        if (path.includes('/node_modules/@fontsource-variable/inter/files/'))
+          return 'binary'
         return null
       })
 
@@ -529,6 +529,71 @@ describe('npm', () => {
       expect(cdnCalled).not.toHaveBeenCalled()
 
       restoreFetch()
+    })
+  })
+
+  describe('remote: false', () => {
+    it('emits file:// URLs for locally installed font files', async () => {
+      const readFile = vi.fn(async (path: string) => {
+        if (path === '/my/project/package.json')
+          return MOCK_PACKAGE_JSON
+        if (path === '/my/project/node_modules/cal-sans/index.css')
+          return MOCK_CAL_SANS_CSS
+        if (path.startsWith('/my/project/node_modules/cal-sans/fonts/'))
+          return 'binary'
+        return null
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile, remote: false, root: '/my/project' })])
+      const { fonts } = await unifont.resolveFont('Cal Sans', { weights: ['600'], formats: ['woff2', 'woff'] })
+
+      expect(fonts.length).toBe(1)
+      expect(fonts[0]!.src).toStrictEqual([
+        { url: 'file:///my/project/node_modules/cal-sans/fonts/webfonts/CalSans-SemiBold.woff2', format: 'woff2' },
+        { url: 'file:///my/project/node_modules/cal-sans/fonts/webfonts/CalSans-SemiBold.woff', format: 'woff' },
+      ])
+    })
+
+    it('warns and drops sources whose files are missing', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const readFile = vi.fn(async (path: string) => {
+        if (path === '/my/project/package.json')
+          return MOCK_PACKAGE_JSON
+        if (path === '/my/project/node_modules/cal-sans/index.css')
+          return MOCK_CAL_SANS_CSS
+        return null
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile, remote: false, root: '/my/project' })])
+      const { fonts } = await unifont.resolveFont('Cal Sans', { weights: ['600'] })
+
+      expect(fonts).toStrictEqual([])
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('CalSans-SemiBold.woff2'))
+
+      warn.mockRestore()
+    })
+
+    it('preserves absolute URLs', async () => {
+      const cssWithAbsoluteUrl = `
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.example.com/roboto.woff2) format('woff2');
+}
+`
+      const readFile = vi.fn(async (path: string) => {
+        if (path === '/my/project/package.json')
+          return MOCK_PACKAGE_JSON
+        if (path === '/my/project/node_modules/@fontsource/roboto/400.css')
+          return cssWithAbsoluteUrl
+        return null
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile, remote: false, root: '/my/project' })])
+      const { fonts } = await unifont.resolveFont('Roboto', { weights: ['400'] })
+
+      expect(fonts[0]!.src[0]).toHaveProperty('url', 'https://fonts.example.com/roboto.woff2')
     })
   })
 

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -50,12 +50,12 @@ export function getOptimizerIdentityFromUrl(provider: OptimizationSupportedProvi
   // TODO: add other providers when they support optimizing
 }
 
-export function mockFetchReturn(condition: RegExp, value: () => unknown) {
+export function mockFetchReturn(condition: RegExp, value: (...args: Parameters<typeof globalThis.fetch>) => unknown) {
   const originalFetch = globalThis.fetch
 
   globalThis.fetch = (...args) => {
     if (condition.test(args[0] as string)) {
-      return value() as any
+      return value(...args) as any
     }
     return originalFetch(...args)
   }


### PR DESCRIPTION
this is two small fixes to the `npm` provider found while investigating https://github.com/nuxt/fonts/issues/830

## 1. only weight 400 resolves

asking for `weights: ['400', '500', '700']` from `@fontsource/nunito` returns a single face at 400, and everything else fell back to a system font, because `index.css` only contains weight 400 normal

this PR maps the requested weights and styles onto the entry points fontsource uses.

## 2. `remote: false` still emits CDN URLs

with the package installed and `remote: false` set, the local files were used to find and parse the CSS but the returned `src` URLs were still rewritten to `https://cdn.jsdelivr.net/npm/<pkg>@<version>/...`.

this now resolves relative URLs against the installed package and emits `file://` URLs instead. absolute `http`, `data:` and `//` URLs are passed through as before. this is similar to https://github.com/unjs/unifont/pull/367, but restricted to `remote: false` - I'll update #367 after merging this...