### PR TITLE
feat(npm): add optional `exists` hook + strip url query strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,11 +339,13 @@ providers.npm({
 Optional function to check whether a file exists. It is used when resolving font files with `remote: false`. When it is not provided, `readFile` is used for the check instead, which reads and decodes each candidate font file in full:
 
 ```js
-import { access } from 'node:fs/promises'
+import { access, readFile } from 'node:fs/promises'
 import { providers } from 'unifont'
 
 providers.npm({
+  readFile: path => readFile(path, 'utf-8').catch(() => null),
   exists: path => access(path).then(() => true).catch(() => false),
+  remote: false,
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -332,6 +332,21 @@ providers.npm({
 })
 ```
 
+##### `exists`
+
+- Type: `(path: string) => Promise<boolean>`
+
+Optional function to check whether a file exists. It is used when resolving font files with `remote: false`. When it is not provided, `readFile` is used for the check instead, which reads and decodes each candidate font file in full:
+
+```js
+import { access } from 'node:fs/promises'
+import { providers } from 'unifont'
+
+providers.npm({
+  exists: path => access(path).then(() => true).catch(() => false),
+})
+```
+
 ##### `root`
 
 - Type: `string`

--- a/src/providers/npm.ts
+++ b/src/providers/npm.ts
@@ -43,6 +43,20 @@ export interface NpmProviderOptions {
    */
   readFile?: (path: string) => Promise<string | null>
   /**
+   * Optional function to check whether a file exists on the local filesystem.
+   * Used when resolving font files with `remote: false`; when not provided,
+   * `readFile` is used instead, which reads and decodes the whole font binary.
+   *
+   * @example
+   * ```ts
+   * import { access } from 'node:fs/promises'
+   * providers.npm({
+   *   exists: path => access(path).then(() => true).catch(() => false),
+   * })
+   * ```
+   */
+  exists?: (path: string) => Promise<boolean>
+  /**
    * Root directory of the project for resolving local packages.
    * Used to find `package.json` and `node_modules`.
    * @default '.' (current working directory)
@@ -175,6 +189,16 @@ function resolveCssFiles(pkgName: string, options: Pick<ResolveFontOptions, 'wei
   return files.length > 0 ? files : [DEFAULT_CSS_FILE]
 }
 
+const URL_SUFFIX_RE = /[?#].*$/
+
+/**
+ * Remove any query string or fragment from a CSS `url()` value. Both are
+ * meaningless for a `file://` URL, so they are dropped rather than preserved.
+ */
+function stripUrlSuffix(url: string): string {
+  return url.replace(URL_SUFFIX_RE, '')
+}
+
 function stripTrailingSlashes(path: string): string {
   let end = path.length
   while (end > 1 && (path[end - 1] === '/' || path[end - 1] === '\\')) {
@@ -193,6 +217,7 @@ export default defineFontProvider('npm', (providerOptions: NpmProviderOptions, c
   const cdn = providerOptions.cdn || DEFAULT_CDN
   const remote = providerOptions.remote ?? true
   const readFile = providerOptions.readFile
+  const exists = providerOptions.exists ?? (path => readFile!(path).then(contents => contents !== null))
   const root = stripTrailingSlashes(providerOptions.root || '.')
 
   // Lazily computed and cached by package.json content hash
@@ -298,9 +323,9 @@ export default defineFontProvider('npm', (providerOptions: NpmProviderOptions, c
           continue
         }
 
-        const filePath = resolve(pkgDir, url)
-        const exists = await readFile!(filePath).then(contents => contents !== null).catch(() => false)
-        if (!exists) {
+        const filePath = resolve(pkgDir, stripUrlSuffix(url))
+        const fileExists = await exists(filePath).catch(() => false)
+        if (!fileExists) {
           console.warn(`Could not find \`${filePath}\` when resolving fonts locally. \`unifont\` will not include this font source.`)
           continue
         }

--- a/src/providers/npm.ts
+++ b/src/providers/npm.ts
@@ -49,9 +49,11 @@ export interface NpmProviderOptions {
    *
    * @example
    * ```ts
-   * import { access } from 'node:fs/promises'
+   * import { access, readFile } from 'node:fs/promises'
    * providers.npm({
+   *   readFile: path => readFile(path, 'utf-8').catch(() => null),
    *   exists: path => access(path).then(() => true).catch(() => false),
+   *   remote: false,
    * })
    * ```
    */

--- a/test/providers/npm.test.ts
+++ b/test/providers/npm.test.ts
@@ -741,6 +741,76 @@ describe('npm', () => {
       warn.mockRestore()
     })
 
+    it('strips query strings and fragments before resolving font files', async () => {
+      const cssWithQuery = `
+@font-face {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  src: url(./files/roboto-latin-400-normal.woff2?v=1) format('woff2'), url(./files/roboto-latin-400-normal.woff#iefix) format('woff');
+}
+`
+      const readFile = vi.fn(async (path: string) => {
+        if (path === '/my/project/package.json')
+          return MOCK_PACKAGE_JSON
+        if (path === '/my/project/node_modules/@fontsource/roboto/400.css')
+          return cssWithQuery
+        if (path.startsWith('/my/project/node_modules/@fontsource/roboto/files/'))
+          return 'binary'
+        return null
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile, remote: false, root: '/my/project' })])
+      const { fonts } = await unifont.resolveFont('Roboto', { weights: ['400'], formats: ['woff2', 'woff'] })
+
+      expect(fonts[0]!.src).toStrictEqual([
+        { url: 'file:///my/project/node_modules/@fontsource/roboto/files/roboto-latin-400-normal.woff2', format: 'woff2' },
+        { url: 'file:///my/project/node_modules/@fontsource/roboto/files/roboto-latin-400-normal.woff', format: 'woff' },
+      ])
+    })
+
+    it('uses `exists` rather than `readFile` to check for font files', async () => {
+      const readFile = vi.fn(async (path: string) => {
+        if (path === '/my/project/package.json')
+          return MOCK_PACKAGE_JSON
+        if (path === '/my/project/node_modules/cal-sans/index.css')
+          return MOCK_CAL_SANS_CSS
+        return null
+      })
+      const exists = vi.fn(async (path: string) => path.startsWith('/my/project/node_modules/cal-sans/fonts/'))
+
+      const unifont = await createUnifont([providers.npm({ readFile, exists, remote: false, root: '/my/project' })])
+      const { fonts } = await unifont.resolveFont('Cal Sans', { weights: ['600'], formats: ['woff2'] })
+
+      expect(fonts[0]!.src).toStrictEqual([
+        { url: 'file:///my/project/node_modules/cal-sans/fonts/webfonts/CalSans-SemiBold.woff2', format: 'woff2' },
+      ])
+      expect(exists).toHaveBeenCalled()
+      expect(readFile).not.toHaveBeenCalledWith(expect.stringContaining('/fonts/'))
+    })
+
+    it('drops sources when `exists` throws', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const readFile = vi.fn(async (path: string) => {
+        if (path === '/my/project/package.json')
+          return MOCK_PACKAGE_JSON
+        if (path === '/my/project/node_modules/cal-sans/index.css')
+          return MOCK_CAL_SANS_CSS
+        return null
+      })
+      const exists = vi.fn(async () => {
+        throw new Error('Permission denied')
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile, exists, remote: false, root: '/my/project' })])
+      const { fonts } = await unifont.resolveFont('Cal Sans', { weights: ['600'] })
+
+      expect(fonts).toStrictEqual([])
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('CalSans-SemiBold.woff2'))
+
+      warn.mockRestore()
+    })
+
     it('preserves absolute URLs', async () => {
       const cssWithAbsoluteUrl = `
 @font-face {


### PR DESCRIPTION
two small things I hit with `remote: false` from `fontless`

1. we need to strip cache-busting queries - this will simply fail to resolve the font
2. we shouldn't need to `readFile` just to check if a file exists... this means `fontless` can swap in `access` to reduce io

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional file-existence check for local npm font resolution.
  - Local font URLs now ignore query strings and fragments when locating files.
  - Missing or inaccessible font files are safely excluded from results.

- **Documentation**
  - Documented the new file-existence callback, fallback behavior, and usage example.

- **Tests**
  - Added coverage for cleaned local URLs, custom existence checks, and failed file checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->