### PR TITLE
feat(npm): add `resolve` callback for locating installed font packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,12 +349,32 @@ providers.npm({
 })
 ```
 
+##### `resolve`
+
+- Type: `(id: string) => string | null | Promise<string | null>`
+- Default: `import.meta.resolve`, falling back to `<root>/node_modules/<id>`
+
+Resolve a package-relative specifier (such as `@fontsource/roboto/index.css`) to an absolute path on disk. Return `null` (or throw) when the package isn't installed; the provider treats that as "not available locally" and falls back to the CDN unless `remote` is `false`.
+
+Supply a resolver for layouts where the package isn't linked into a `node_modules` directory under `root`: pnpm's isolated store, hoisting to a monorepo root, Yarn PnP, or a bundler alias.
+
+```js
+import { readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { providers } from 'unifont'
+
+providers.npm({
+  readFile: path => readFile(path, 'utf-8').catch(() => null),
+  resolve: id => fileURLToPath(import.meta.resolve(id)),
+})
+```
+
 ##### `root`
 
 - Type: `string`
 - Default: `'.'`
 
-Root directory of the project, used to find `package.json` and `node_modules` when resolving local packages:
+Root directory of the project, used to find `package.json`, and `node_modules` when no `resolve` function is provided:
 
 ```js
 import { providers } from 'unifont'

--- a/src/providers/npm.ts
+++ b/src/providers/npm.ts
@@ -1,7 +1,7 @@
 import type { FontFaceData, ResolveFontOptions } from '../types'
 
-import { resolve } from 'node:path'
-import { pathToFileURL } from 'node:url'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { hash } from 'ohash'
 
 import { extractFontFaceData } from '../css/parse'
@@ -59,8 +59,32 @@ export interface NpmProviderOptions {
    */
   exists?: (path: string) => Promise<boolean>
   /**
+   * Optional function to resolve a package-relative specifier (such as
+   * `@fontsource/roboto/index.css`) to an absolute path on disk.
+   *
+   * Return `null` (or throw) when the package is not installed; the provider
+   * treats that as "not available locally" and falls back to the CDN unless
+   * `remote` is `false`.
+   *
+   * When not provided, `import.meta.resolve` is used, falling back to
+   * `<root>/node_modules/<specifier>`. Supplying a resolver is necessary for
+   * layouts where the package is not linked into a `node_modules` directory
+   * under `root`: pnpm's isolated store, hoisting to a monorepo root, Yarn PnP,
+   * or a bundler alias.
+   *
+   * @example
+   * ```ts
+   * import { fileURLToPath } from 'node:url'
+   * providers.npm({
+   *   resolve: id => fileURLToPath(import.meta.resolve(id)),
+   * })
+   * ```
+   */
+  resolve?: (id: string) => string | null | Promise<string | null>
+  /**
    * Root directory of the project for resolving local packages.
-   * Used to find `package.json` and `node_modules`.
+   * Used to find `package.json`, and `node_modules` when no `resolve` function
+   * is provided.
    * @default '.' (current working directory)
    */
   root?: string
@@ -209,6 +233,18 @@ function stripTrailingSlashes(path: string): string {
   return path.slice(0, end)
 }
 
+/**
+ * Strip the resolved CSS specifier back off to recover the package directory,
+ * which is where the stylesheet's relative font URLs are anchored.
+ */
+function packageDirFor(path: string, cssFile: string): string {
+  const suffix = `/${cssFile}`
+  if (path.replaceAll('\\', '/').endsWith(suffix)) {
+    return path.slice(0, path.length - suffix.length)
+  }
+  return dirname(path)
+}
+
 interface DetectedFont {
   family: string
   pkgName: string
@@ -221,6 +257,32 @@ export default defineFontProvider('npm', (providerOptions: NpmProviderOptions, c
   const readFile = providerOptions.readFile
   const exists = providerOptions.exists ?? (path => readFile!(path).then(contents => contents !== null))
   const root = stripTrailingSlashes(providerOptions.root || '.')
+
+  // `import.meta.resolve` (which resolves relative to `unifont` itself) is only
+  // consulted when the default root is in use.
+  const resolveId = providerOptions.resolve ?? ((id: string) => {
+    if (!providerOptions.root && typeof import.meta.resolve === 'function') {
+      try {
+        const url = import.meta.resolve(id)
+        if (url.startsWith('file:')) {
+          return fileURLToPath(url)
+        }
+      }
+      catch {
+        // Not resolvable from `unifont`; fall through to `root`
+      }
+    }
+    return `${root}/node_modules/${id}`
+  })
+
+  async function resolvePath(id: string): Promise<string | null> {
+    try {
+      return await resolveId(id) ?? null
+    }
+    catch {
+      return null
+    }
+  }
 
   // Lazily computed and cached by package.json content hash
   let detectedFonts: Map<string, DetectedFont> | undefined
@@ -348,28 +410,41 @@ export default defineFontProvider('npm', (providerOptions: NpmProviderOptions, c
       return null
     }
 
-    const stylesheets = await Promise.all(cssFiles.map(cssFile => readFile(`${root}/node_modules/${pkgName}/${cssFile}`).catch(() => null)))
+    const stylesheets = await Promise.all(cssFiles.map(async (cssFile) => {
+      const path = await resolvePath(`${pkgName}/${cssFile}`)
+      if (!path) {
+        return null
+      }
+      const css = await readFile(path).catch(() => null)
+      return css ? { css, pkgDir: packageDirFor(path, cssFile) } : null
+    }))
+
+    const found = stylesheets.filter(entry => entry !== null)
+    if (found.length === 0) {
+      return null
+    }
+
+    if (!remote) {
+      const localFaces: FontFaceData[] = []
+      for (const { css, pkgDir } of found) {
+        localFaces.push(...await resolveUrlsToLocalFiles(extractFontFaceData(css, family), pkgDir))
+      }
+      return localFaces.length > 0 ? cleanFontFaces(localFaces, formats) : null
+    }
 
     const fontFaces: FontFaceData[] = []
-    for (const css of stylesheets) {
-      if (css) {
-        fontFaces.push(...extractFontFaceData(css, family))
-      }
+    for (const { css } of found) {
+      fontFaces.push(...extractFontFaceData(css, family))
     }
 
     if (fontFaces.length === 0) {
       return null
     }
 
-    if (!remote) {
-      const localFaces = await resolveUrlsToLocalFiles(fontFaces, `${root}/node_modules/${pkgName}`)
-      return localFaces.length > 0 ? cleanFontFaces(localFaces, formats) : null
-    }
-
     // Resolve relative URLs to absolute CDN URLs using the installed version
     let version = 'latest'
     try {
-      const localPkgJson = await readFile(`${root}/node_modules/${pkgName}/package.json`)
+      const localPkgJson = await readFile(`${found[0]!.pkgDir}/package.json`)
       if (localPkgJson) {
         const parsed = JSON.parse(localPkgJson) as { version?: string }
         if (parsed.version) {

--- a/test/providers/npm.test.ts
+++ b/test/providers/npm.test.ts
@@ -633,6 +633,130 @@ describe('npm', () => {
     })
   })
 
+  describe('resolve', () => {
+    it('uses a custom resolver in preference to root', async () => {
+      const resolve = vi.fn((id: string) => `/pnpm/store/${id}`)
+      const readFile = vi.fn(async (path: string) => {
+        if (path === '/my/project/package.json')
+          return MOCK_PACKAGE_JSON
+        if (path === '/pnpm/store/@fontsource/roboto/index.css')
+          return MOCK_ROBOTO_CSS
+        if (path === '/pnpm/store/@fontsource/roboto/package.json')
+          return MOCK_PKG_VERSION_JSON
+        return null
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile, resolve, root: '/my/project' })])
+      const { fonts } = await unifont.resolveFont('Roboto')
+
+      expect(fonts.length).toBeGreaterThan(0)
+      expect(resolve).toHaveBeenCalledWith('@fontsource/roboto/index.css')
+      expect(readFile).not.toHaveBeenCalledWith('/my/project/node_modules/@fontsource/roboto/index.css')
+      for (const font of fonts) {
+        for (const src of font.src) {
+          if ('url' in src) {
+            expect(src.url).toContain('@fontsource/roboto@5.2.9')
+          }
+        }
+      }
+    })
+
+    it('emits file:// URLs anchored on the resolved package directory', async () => {
+      const resolve = vi.fn((id: string) => `/pnpm/store/${id}`)
+      const readFile = vi.fn(async (path: string) => {
+        if (path === './package.json')
+          return MOCK_PACKAGE_JSON
+        if (path === '/pnpm/store/cal-sans/index.css')
+          return MOCK_CAL_SANS_CSS
+        if (path.startsWith('/pnpm/store/cal-sans/fonts/'))
+          return 'binary'
+        return null
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile, resolve, remote: false })])
+      const { fonts } = await unifont.resolveFont('Cal Sans', { weights: ['600'], formats: ['woff2'] })
+
+      expect(fonts[0]!.src).toStrictEqual([
+        { url: 'file:///pnpm/store/cal-sans/fonts/webfonts/CalSans-SemiBold.woff2', format: 'woff2' },
+      ])
+    })
+
+    it('falls back to the CDN when resolution fails', async () => {
+      const resolve = vi.fn(() => {
+        const error = new Error('Cannot find module') as Error & { code: string }
+        error.code = 'ERR_MODULE_NOT_FOUND'
+        throw error
+      })
+      const readFile = vi.fn(async () => null)
+
+      const restoreFetch = mockFetchReturn(/@fontsource\/roboto/, () =>
+        new Response(MOCK_ROBOTO_CSS))
+
+      const unifont = await createUnifont([providers.npm({ readFile, resolve })])
+      const { fonts } = await unifont.resolveFont('Roboto')
+
+      expect(fonts.length).toBeGreaterThan(0)
+      expect(readFile).not.toHaveBeenCalledWith(expect.stringContaining('roboto/index.css'))
+
+      restoreFetch()
+    })
+
+    it('resolves nothing and makes no request when resolution fails with remote: false', async () => {
+      const resolve = vi.fn(() => null)
+      const readFile = vi.fn(async () => null)
+
+      const cdnCalled = vi.fn()
+      const restoreFetch = mockFetchReturn(/./, () => {
+        cdnCalled()
+        return new Response(MOCK_ROBOTO_CSS)
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile, resolve, remote: false })])
+      const { fonts } = await unifont.resolveFont('Roboto')
+
+      expect(fonts).toStrictEqual([])
+      expect(cdnCalled).not.toHaveBeenCalled()
+
+      restoreFetch()
+    })
+
+    it('resolves installed packages via import.meta.resolve by default', async () => {
+      const readFile = vi.fn(async (path: string) => {
+        if (path.endsWith('/css-tree/package.json'))
+          return MOCK_ROBOTO_CSS
+        if (path.includes('/css-tree/files/'))
+          return 'binary'
+        return null
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile, remote: false })])
+      const { fonts } = await unifont.resolveFont('Roboto', {
+        options: { npm: { package: 'css-tree', file: 'package.json' } },
+      })
+
+      expect(fonts.length).toBe(3)
+      expect(readFile).toHaveBeenCalledWith(expect.stringContaining('/node_modules/css-tree/package.json'))
+      expect(readFile).not.toHaveBeenCalledWith('./node_modules/css-tree/package.json')
+    })
+
+    it('supports asynchronous resolvers', async () => {
+      const resolve = vi.fn(async (id: string) => `/elsewhere/${id}`)
+      const readFile = vi.fn(async (path: string) => {
+        if (path === '/elsewhere/@fontsource/roboto/400.css')
+          return MOCK_ROBOTO_CSS
+        if (path.startsWith('/elsewhere/@fontsource/roboto/files/'))
+          return 'binary'
+        return null
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile, resolve, remote: false })])
+      const { fonts } = await unifont.resolveFont('Roboto', { weights: ['400'], styles: ['normal'], formats: ['woff2'] })
+
+      expect(fonts.length).toBe(3)
+      expect(fonts[0]!.src[0]).toHaveProperty('url', 'file:///elsewhere/@fontsource/roboto/files/roboto-latin-400-normal.woff2')
+    })
+  })
+
   describe('remote: false', () => {
     it('emits file:// URLs for locally installed font files', async () => {
       const readFile = vi.fn(async (path: string) => {

--- a/test/providers/npm.test.ts
+++ b/test/providers/npm.test.ts
@@ -739,6 +739,48 @@ describe('npm', () => {
       expect(readFile).not.toHaveBeenCalledWith('./node_modules/css-tree/package.json')
     })
 
+    it('anchors font URLs on the parent directory when the resolved path is aliased', async () => {
+      const resolve = vi.fn(() => '/aliased/roboto.css')
+      const readFile = vi.fn(async (path: string) => {
+        if (path === '/aliased/roboto.css')
+          return MOCK_ROBOTO_CSS
+        if (path.startsWith('/aliased/files/'))
+          return 'binary'
+        return null
+      })
+
+      const unifont = await createUnifont([providers.npm({ readFile, resolve, remote: false })])
+      const { fonts } = await unifont.resolveFont('Roboto', { weights: ['400'], styles: ['normal'], formats: ['woff2'] })
+
+      expect(fonts[0]!.src[0]).toHaveProperty('url', 'file:///aliased/files/roboto-latin-400-normal.woff2')
+    })
+
+    it('falls back to the CDN when the resolved stylesheet has no matching family', async () => {
+      const resolve = vi.fn((id: string) => `/elsewhere/${id}`)
+      const readFile = vi.fn(async (path: string) => {
+        if (path.startsWith('/elsewhere/@fontsource/roboto/'))
+          return MOCK_MULTI_FAMILY_CSS.replace(/'Roboto'/, '"Other"')
+        return null
+      })
+
+      const restoreFetch = mockFetchReturn(/@fontsource\/roboto/, () =>
+        new Response(MOCK_ROBOTO_CSS))
+
+      const unifont = await createUnifont([providers.npm({ readFile, resolve })])
+      const { fonts } = await unifont.resolveFont('Roboto')
+
+      expect(fonts.length).toBe(3)
+      for (const font of fonts) {
+        for (const src of font.src) {
+          if ('url' in src) {
+            expect(src.url).toMatch(/^https:\/\/cdn\.jsdelivr\.net\/npm\//)
+          }
+        }
+      }
+
+      restoreFetch()
+    })
+
     it('supports asynchronous resolvers', async () => {
       const resolve = vi.fn(async (id: string) => `/elsewhere/${id}`)
       const readFile = vi.fn(async (path: string) => {


### PR DESCRIPTION
the `npm` provider currently finds locally installed packages by string concatenation:

```ts
readFile(`${root}/node_modules/${pkgName}/${cssFile}`)
```

which assumes a flat, hoisted `node_modules` directly under `root`...

that works fine for direct dependencies, but it can miss pnpm's isolated store, packages hoisted to a monorepo root rather than the app dir, and bundler aliases...

this adds an optional `resolve` hook so the host environment can resolve packages

```ts
providers.npm({
  readFile: path => readFile(path, 'utf-8').catch(() => null),
  resolve: id => fileURLToPath(import.meta.resolve(id)),
})
```
