### PR TITLE
fix(fontshare): resolve font faces for weight ranges

### DIFF
--- a/src/providers/fontshare.ts
+++ b/src/providers/fontshare.ts
@@ -42,11 +42,32 @@ export default defineFontProvider('fontshare', async (_options, ctx) => {
       axis = font.axes.find(e => e.property === 'wght')
     }
 
-    const weights = prepareWeights({
+    const staticWeights = font.styles.filter(s => !s.is_variable).map(s => String(s.weight.weight))
+    const axisRange = axis ? `${axis.range_left} ${axis.range_right}` : undefined
+
+    const weights = new Set<string>()
+    for (const { weight, variable } of prepareWeights({
       inputWeights: options.weights,
       hasVariableWeights: hasVariable && !!axis,
-      weights: font.styles.map(s => String(s.weight.weight)),
-    }).map(w => w.weight)
+      weights: staticWeights,
+    })) {
+      if (!variable) {
+        weights.add(weight)
+        continue
+      }
+      const [min, max] = weight.split(' ').map(Number) as [number, number]
+      // fontshare serves the variable file as-is, so it can only satisfy a range
+      // that covers the whole axis; narrower ranges resolve to static weights
+      if (axis && min <= axis.range_left && max >= axis.range_right) {
+        weights.add(axisRange!)
+        continue
+      }
+      for (const staticWeight of staticWeights) {
+        if (Number(staticWeight) >= min && Number(staticWeight) <= max) {
+          weights.add(staticWeight)
+        }
+      }
+    }
 
     for (const style of font.styles) {
       if (style.is_italic && !options.styles.includes('italic')) {
@@ -55,10 +76,10 @@ export default defineFontProvider('fontshare', async (_options, ctx) => {
       if (!style.is_italic && !options.styles.includes('normal')) {
         continue
       }
-      if (style.is_variable && axis && !weights.includes(`${axis.range_left} ${axis.range_right}`)) {
+      if (style.is_variable && (!axisRange || !weights.has(axisRange))) {
         continue
       }
-      if (!style.is_variable && !weights.includes(String(style.weight.weight))) {
+      if (!style.is_variable && !weights.has(String(style.weight.weight))) {
         continue
       }
       numbers.push(style.weight.number)

--- a/test/providers/fontshare.test.ts
+++ b/test/providers/fontshare.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { createUnifont, providers } from '../../src'
 import { mockFetchReturn, sanitizeFontSource } from '../utils'
 
@@ -173,6 +173,77 @@ describe('fontshare', () => {
       })
       expect(fonts.length).toBe(1)
       expect(fonts.flatMap(font => font.src.map(source => 'name' in source ? source.name : source.format))).toStrictEqual(['woff2', 'woff', 'truetype'])
+    })
+  })
+
+  describe('weight ranges', () => {
+    const staticStyles = [200, 300, 400, 500, 600, 700, 800].map(weight => ({
+      is_italic: false,
+      is_variable: false,
+      weight: { number: weight, weight },
+    }))
+
+    const meta = [{
+      slug: 'fixture',
+      name: 'Fixture',
+      category: 'Sans Serif',
+      axes: [{ name: 'wght', property: 'wght', range_default: 400, range_left: 200, range_right: 800 }],
+      styles: [...staticStyles, { is_italic: false, is_variable: true, weight: { number: 1, weight: 0 } }],
+    }]
+
+    let requestedNumbers: string[] = []
+    let restore: (() => void) | undefined
+
+    afterEach(() => {
+      restore?.()
+      restore = undefined
+      requestedNumbers = []
+    })
+
+    function mockApi() {
+      restore?.()
+      restore = mockFetchReturn(/api\.fontshare\.com/, (request) => {
+        const url = String(request)
+        if (url.includes('/fonts?')) {
+          return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ fonts: meta, has_more: false }) })
+        }
+        requestedNumbers = url.split('@')[1]!.split(',')
+        const css = requestedNumbers.map(number => `@font-face {
+          font-family: 'Fixture';
+          font-style: normal;
+          font-weight: ${number === '1' ? '200 800' : number};
+          src: url(https://cdn.fontshare.com/${number}.woff2) format('woff2');
+        }`).join('\n')
+        return Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve(css) })
+      })
+    }
+
+    async function resolve(weights: string[]) {
+      mockApi()
+      const unifont = await createUnifont([providers.fontshare()])
+      const { fonts } = await unifont.resolveFont('Fixture', { weights, styles: ['normal'], subsets: ['latin'], formats: ['woff2'] })
+      return fonts
+    }
+
+    it('should resolve a range to the static weights it covers', async () => {
+      const fonts = await resolve(['400 700'])
+      expect(fonts.map(font => font.weight)).toStrictEqual([400, 500, 600, 700])
+    })
+
+    it('should resolve a range covering the axis to the variable font', async () => {
+      const fonts = await resolve(['100 900'])
+      expect(fonts.map(font => font.weight)).toStrictEqual([[200, 800]])
+      expect(requestedNumbers).toStrictEqual(['1'])
+    })
+
+    it('should resolve a range identically to the equivalent discrete weights', async () => {
+      const range = await resolve(['300 500'])
+      const discrete = await resolve(['300', '400', '500'])
+      expect(range).toStrictEqual(discrete)
+    })
+
+    it('should resolve nothing for a range outside the available weights', async () => {
+      expect(await resolve(['900 1000'])).toStrictEqual([])
     })
   })
 


### PR DESCRIPTION
while testing the change of the default `@nuxt/fonts` weight from `[400]` to `['400 700']`, every `fontshare` family started failing to resolve:

```
Error: Could not produce font face declaration from `fontshare` for font family `Satoshi`.
```

this is because `fontshare` returns no faces at all whenever the requested weight is a range rather than a discrete list - it has to _exactly_ equal the family's own axis range.

this PR expands a range to the static weights it covers, and keeps the variable file only when the requested range covers the whole axis ...

(the other providers all handle ranges already)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved font weight selection for Fontshare fonts.
  * Variable font styles are now used only when the complete weight range is requested.
  * Requests for partial or unsupported ranges now correctly select matching static weights or return no results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->