### PR TITLE
fix: install proxy dispatcher when another undici owns the global one

### DIFF
--- a/src/env-proxy.ts
+++ b/src/env-proxy.ts
@@ -13,6 +13,10 @@ import process from 'node:process'
 
 let installed = false
 
+function isDefaultAgent(dispatcher: unknown): boolean {
+  return (dispatcher as { constructor?: { name?: string } })?.constructor?.name === 'Agent'
+}
+
 export async function installProxyDispatcher(): Promise<void> {
   if (installed)
     return
@@ -24,9 +28,8 @@ export async function installProxyDispatcher(): Promise<void> {
   installed = true
 
   try {
-    const { Agent, EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } = await import('undici')
-    const current = getGlobalDispatcher()
-    if (current instanceof Agent && !(current instanceof EnvHttpProxyAgent)) {
+    const { EnvHttpProxyAgent, getGlobalDispatcher, setGlobalDispatcher } = await import('undici')
+    if (isDefaultAgent(getGlobalDispatcher())) {
       setGlobalDispatcher(new EnvHttpProxyAgent())
     }
   }

--- a/test/env-proxy.test.ts
+++ b/test/env-proxy.test.ts
@@ -15,6 +15,24 @@ function dispatcherName(): string {
   return getGlobalDispatcher().constructor.name
 }
 
+function foreignDispatcher(name: string) {
+  const Cls = class {
+    dispatch() {
+      return true
+    }
+
+    close() {
+      return Promise.resolve()
+    }
+
+    destroy() {
+      return Promise.resolve()
+    }
+  }
+  Object.defineProperty(Cls, 'name', { value: name })
+  return new Cls()
+}
+
 describe('installProxyDispatcher', () => {
   const originalDispatcher = getGlobalDispatcher()
   const proxyEnvKeys = ['HTTPS_PROXY', 'HTTP_PROXY', 'https_proxy', 'http_proxy'] as const
@@ -73,6 +91,25 @@ describe('installProxyDispatcher', () => {
     await install()
     expect(getGlobalDispatcher()).toBe(custom)
     expect(dispatcherName()).toBe('ProxyAgent')
+  })
+
+  it('replaces a default agent installed by a different copy of undici', async () => {
+    process.env.HTTPS_PROXY = 'http://127.0.0.1:9999'
+    const foreign = foreignDispatcher('Agent')
+    setGlobalDispatcher(foreign as never)
+    const install = await freshInstall()
+    await install()
+    expect(getGlobalDispatcher()).not.toBe(foreign)
+    expect(dispatcherName()).toBe('EnvHttpProxyAgent')
+  })
+
+  it('does not trample a custom dispatcher from a different copy of undici', async () => {
+    process.env.HTTPS_PROXY = 'http://127.0.0.1:9999'
+    const foreign = foreignDispatcher('ProxyAgent')
+    setGlobalDispatcher(foreign as never)
+    const install = await freshInstall()
+    await install()
+    expect(getGlobalDispatcher()).toBe(foreign)
   })
 
   it('is idempotent across repeated calls', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/fonts/issues/769

### 📚 Description

with `HTTP_PROXY` set, unifont only proxies requests if it's the first thing to touch the global dispatcher. but in `@nuxt/fonts`, `ofetch` and `node-fetch-native` bundle their own `undici`

this switches the guard to a name check, so a default `Agent` from any copy is replaced, while anything deliberate (`ProxyAgent`, `MockAgent`, `EnvHttpProxyAgent`, a user subclass) is still left alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy dispatcher detection across different copies of the networking library.
  * Ensured the default dispatcher is correctly replaced with the configured proxy.
  * Preserved custom proxy dispatchers instead of overwriting them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->