### PR TITLE
refactor!: make the provider fetcher internal

### DIFF
--- a/docs/content/docs/8.custom-providers.md
+++ b/docs/content/docs/8.custom-providers.md
@@ -33,16 +33,14 @@ const unifont = await createUnifont([
 
 ## The context
 
-`unifont` passes two globally-configured primitives into each provider via a `ctx`.
-
-`ctx.fetch` retries failures and rewrites the built-in providers' URLs to [`apiBase`](/docs/browser). Your own endpoints aren't rewritten, so a custom provider works in a browser only if its API sends CORS headers or you proxy it yourself.
+`unifont` passes the configured cache into each provider via a `ctx`. Request your own endpoints with the global `fetch`: [`apiBase`](/docs/browser) only rewrites the built-in providers' URLs, so a custom provider works in a browser only if its API sends CORS headers or you proxy it yourself.
 
 `ctx.storage.getItem(key, init)` is a cache that fills itself. Pass a function and it runs once, then reads from whatever storage the user configured:
 
 ```ts
 export const foundry = defineFontProvider('foundry', async (options: FoundryOptions, ctx) => {
   const families = await ctx.storage.getItem('foundry:index.json', () =>
-    ctx.fetch('https://api.foundry.example/families').then(res => res.json()),
+    fetch('https://api.foundry.example/families').then(res => res.json()),
   )
   // …
 })
@@ -92,7 +90,7 @@ async resolveFont(family, options) {
 
   return {
     fonts: await ctx.storage.getItem(`foundry:${family}-${hash(options)}.json`, async () => {
-      const css = await ctx.fetch(match.cssUrl).then(res => res.text())
+      const css = await fetch(match.cssUrl).then(res => res.text())
       return parseIntoFontFaceData(css)
     }),
     fallbacks: ['sans-serif'],

--- a/src/api-base.ts
+++ b/src/api-base.ts
@@ -1,4 +1,4 @@
-import type { ProviderContext } from './types'
+import type { APIFetch } from './internal'
 import { hasWindow, provider } from 'std-env'
 import { fetchWithRetries } from './fetch'
 import { formatFromUserAgent } from './providers/google'
@@ -71,7 +71,7 @@ export function resolveAPIBase(apiBase: string | false | undefined): string | un
  * A browser cannot set `user-agent`, which is how Google's endpoints pick a font format, so the
  * requested format moves into the query string for the proxy to apply on our behalf.
  */
-export function createAPIFetch(configuredAPIBase: string | false | undefined): ProviderContext['fetch'] {
+export function createAPIFetch(configuredAPIBase: string | false | undefined): APIFetch {
   const apiBase = resolveAPIBase(configuredAPIBase)
   if (!apiBase) {
     return fetchWithRetries

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -1,0 +1,22 @@
+import type { ProviderContext } from './types'
+
+/**
+ * Requests a provider API, retrying transient failures and routing the request through the
+ * `apiBase` proxy if one is configured.
+ *
+ * This is not part of the public provider context: custom providers request their own endpoints
+ * directly, as those are never proxied anyway.
+ */
+export type APIFetch = (url: string, init?: RequestInit) => Promise<Response>
+
+/** Key of the fetcher `unifont` attaches to the context it hands to the built-in providers. */
+export const API_FETCH: unique symbol = Symbol('unifont:fetch')
+
+export interface InternalProviderContext extends ProviderContext {
+  [API_FETCH]: APIFetch
+}
+
+/** Requests a provider API through the fetcher `unifont` attached to the provider context. */
+export function fetchAPI(ctx: ProviderContext, url: string, init?: RequestInit): Promise<Response> {
+  return (ctx as InternalProviderContext)[API_FETCH](url, init)
+}

--- a/src/providers/adobe.ts
+++ b/src/providers/adobe.ts
@@ -2,6 +2,7 @@ import type { FontStyles, ProviderContext, ResolveFontOptions } from '../types'
 
 import { hash } from 'ohash'
 import { extractFontFaceData } from '../css/parse'
+import { fetchAPI } from '../internal'
 import { defineFontProvider, prepareWeights } from '../utils'
 
 export interface AdobeProviderOptions {
@@ -9,7 +10,7 @@ export interface AdobeProviderOptions {
 }
 
 async function getAdobeFontMeta(ctx: ProviderContext, id: string): Promise<AdobeFontKit> {
-  const { kit } = await ctx.fetch(`https://typekit.com/api/v1/json/kits/${id}/published`).then(res => res.json() as Promise<{ kit: AdobeFontKit }>)
+  const { kit } = await fetchAPI(ctx, `https://typekit.com/api/v1/json/kits/${id}/published`).then(res => res.json() as Promise<{ kit: AdobeFontKit }>)
   return kit
 }
 
@@ -95,7 +96,7 @@ export default defineFontProvider('adobe', async (options: AdobeProviderOptions,
       if (styles.length === 0) {
         continue
       }
-      const css = await ctx.fetch(`https://use.typekit.net/${kit.id}.css`).then(res => res.text())
+      const css = await fetchAPI(ctx, `https://use.typekit.net/${kit.id}.css`).then(res => res.text())
 
       // TODO: Not sure whether this css_names array always has a single element. Still need to investigate.
       const cssName = font.css_names[0] ?? family.toLowerCase().split(' ').join('-')

--- a/src/providers/bunny.ts
+++ b/src/providers/bunny.ts
@@ -2,6 +2,7 @@ import type { FontFaceData, ResolveFontOptions } from '../types'
 
 import { hash } from 'ohash'
 import { extractFontFaceData } from '../css/parse'
+import { fetchAPI } from '../internal'
 import { cleanFontFaces, defineFontProvider, filterKnownStyles, prepareWeights, splitCssIntoSubsets } from '../utils'
 
 const BASE_URL = 'https://fonts.bunny.net'
@@ -18,7 +19,7 @@ function getFallbacks(category: string): string[] | undefined {
 export default defineFontProvider('bunny', async (_options, ctx) => {
   const familyMap = new Map<string, string>()
 
-  const fonts = await ctx.storage.getItem('bunny:meta.json', () => ctx.fetch(`${BASE_URL}/list`).then(res => res.json() as Promise<BunnyFontMeta>))
+  const fonts = await ctx.storage.getItem('bunny:meta.json', () => fetchAPI(ctx, `${BASE_URL}/list`).then(res => res.json() as Promise<BunnyFontMeta>))
   for (const [id, family] of Object.entries(fonts)) {
     familyMap.set(family.familyName, id)
   }
@@ -40,7 +41,7 @@ export default defineFontProvider('bunny', async (_options, ctx) => {
 
     const resolvedVariants = weights.flatMap(w => Array.from(styles, s => `${w.weight}${s}`))
 
-    const css = await ctx.fetch(`${BASE_URL}/css?family=${id}:${resolvedVariants.join(',')}`).then(res => res.text())
+    const css = await fetchAPI(ctx, `${BASE_URL}/css?family=${id}:${resolvedVariants.join(',')}`).then(res => res.text())
 
     const resolvedFontFaceData: FontFaceData[] = []
 

--- a/src/providers/fontshare.ts
+++ b/src/providers/fontshare.ts
@@ -2,6 +2,7 @@ import type { FontStyles, ResolveFontOptions } from '../types'
 
 import { hash } from 'ohash'
 import { extractFontFaceData } from '../css/parse'
+import { fetchAPI } from '../internal'
 import { cleanFontFaces, defineFontProvider, prepareWeights } from '../utils'
 
 const BASE_URL = 'https://api.fontshare.com/v2'
@@ -22,7 +23,7 @@ export default defineFontProvider('fontshare', async (_options, ctx) => {
     let offset = 0
     let chunk
     do {
-      chunk = await ctx.fetch(`${BASE_URL}/fonts?offset=${offset}&limit=100`).then(res => res.json() as Promise<{ fonts: FontshareFontMeta[], has_more: boolean }>)
+      chunk = await fetchAPI(ctx, `${BASE_URL}/fonts?offset=${offset}&limit=100`).then(res => res.json() as Promise<{ fonts: FontshareFontMeta[], has_more: boolean }>)
       fonts.push(...chunk.fonts)
       offset++
     } while (chunk.has_more)
@@ -88,7 +89,7 @@ export default defineFontProvider('fontshare', async (_options, ctx) => {
     if (numbers.length === 0)
       return []
 
-    const css = await ctx.fetch(`${BASE_URL}/css?f[]=${font.slug}@${numbers.join(',')}`).then(res => res.text())
+    const css = await fetchAPI(ctx, `${BASE_URL}/css?f[]=${font.slug}@${numbers.join(',')}`).then(res => res.text())
 
     const fontFaces = extractFontFaceData(css)
     for (const face of fontFaces) {

--- a/src/providers/fontsource.ts
+++ b/src/providers/fontsource.ts
@@ -1,6 +1,7 @@
 import type { FontFaceData, ProviderContext, ResolveFontOptions } from '../types'
 
 import { hash } from 'ohash'
+import { fetchAPI } from '../internal'
 import { cleanFontFaces, defineFontProvider, filterKnownStyles, prepareWeights } from '../utils'
 
 const BASE_URL = 'https://api.fontsource.org/v1'
@@ -21,7 +22,7 @@ function pickFontsourceAxisSlug(axes: string[]): 'wght' | 'standard' | 'full' {
 }
 
 async function getVariableAxes(ctx: ProviderContext, font: FontsourceFontMeta) {
-  return await ctx.storage.getItem(`fontsource:${font.family}-axes.json`, () => ctx.fetch(`${BASE_URL}/variable/${font.id}`).then(res => res.json() as Promise<FontsourceVariableFontDetail>))
+  return await ctx.storage.getItem(`fontsource:${font.family}-axes.json`, () => fetchAPI(ctx, `${BASE_URL}/variable/${font.id}`).then(res => res.json() as Promise<FontsourceVariableFontDetail>))
 }
 
 // There are others like display and handwriting but these are not valid
@@ -34,7 +35,7 @@ function getFallbacks(category: string): string[] | undefined {
 }
 
 export default defineFontProvider('fontsource', async (_options, ctx) => {
-  const fonts = await ctx.storage.getItem('fontsource:meta.json', () => ctx.fetch(`${BASE_URL}/fonts`).then(res => res.json() as Promise<FontsourceFontMeta[]>))
+  const fonts = await ctx.storage.getItem('fontsource:meta.json', () => fetchAPI(ctx, `${BASE_URL}/fonts`).then(res => res.json() as Promise<FontsourceFontMeta[]>))
   const familyMap = new Map<string, FontsourceFontMeta>()
 
   for (const meta of fonts) {
@@ -52,7 +53,7 @@ export default defineFontProvider('fontsource', async (_options, ctx) => {
     if (weights.length === 0 || styles.length === 0)
       return []
 
-    const fontDetail = await ctx.fetch(`${BASE_URL}/fonts/${font.id}`).then(res => res.json() as Promise<FontsourceFontDetail>)
+    const fontDetail = await fetchAPI(ctx, `${BASE_URL}/fonts/${font.id}`).then(res => res.json() as Promise<FontsourceFontDetail>)
     const fontFaceData: FontFaceData[] = []
 
     for (const subset of subsets) {

--- a/src/providers/google.ts
+++ b/src/providers/google.ts
@@ -2,6 +2,7 @@ import type { FontFaceData, FontFormat, FontStyles, ResolveFontOptions } from '.
 
 import { hash } from 'ohash'
 import { extractFontFaceData } from '../css/parse'
+import { fetchAPI } from '../internal'
 import { cleanFontFaces, defineFontProvider, prepareWeights, splitCssIntoSubsets } from '../utils'
 
 type VariableAxis = 'opsz' | 'slnt' | 'wdth' | (string & {})
@@ -66,7 +67,7 @@ function getFallbacks(category: string): string[] | undefined {
 }
 
 export default defineFontProvider('google', async (providerOptions: GoogleProviderOptions, ctx) => {
-  const { familyMetadataList: googleFonts } = await ctx.storage.getItem('google:meta.json', () => ctx.fetch('https://fonts.google.com/metadata/fonts').then(res => res.json() as Promise<{ familyMetadataList: FontIndexMeta[] }>))
+  const { familyMetadataList: googleFonts } = await ctx.storage.getItem('google:meta.json', () => fetchAPI(ctx, 'https://fonts.google.com/metadata/fonts').then(res => res.json() as Promise<{ familyMetadataList: FontIndexMeta[] }>))
 
   const styleMap = {
     italic: '1',
@@ -170,7 +171,7 @@ export default defineFontProvider('google', async (providerOptions: GoogleProvid
         if (glyphs) {
           url += `&text=${encodeURIComponent(glyphs)}`
         }
-        const rawCss = await ctx.fetch(url, {
+        const rawCss = await fetchAPI(ctx, url, {
           headers: {
             'user-agent': userAgent,
           },

--- a/src/providers/googleicons.ts
+++ b/src/providers/googleicons.ts
@@ -1,6 +1,7 @@
 import type { ResolveFontOptions } from '../types'
 import { hash } from 'ohash'
 import { extractFontFaceData } from '../css/parse'
+import { fetchAPI } from '../internal'
 import { cleanFontFaces, defineFontProvider } from '../utils'
 import { userAgents } from './google'
 
@@ -32,9 +33,7 @@ export interface GoogleiconsFamilyOptions {
 
 export default defineFontProvider('googleicons', async (providerOptions: GoogleiconsProviderOptions, ctx) => {
   const googleIcons = await ctx.storage.getItem('googleicons:meta.json', async () => {
-    const data = await ctx.fetch(
-      'https://fonts.google.com/metadata/icons?key=material_symbols&incomplete=true',
-    ).then(res => res.text())
+    const data = await fetchAPI(ctx, 'https://fonts.google.com/metadata/icons?key=material_symbols&incomplete=true').then(res => res.text())
     const response: { families: string[] } = JSON.parse(
       data.substring(data.indexOf('\n') + 1), // remove the first line which makes it an invalid JSON
     )
@@ -55,7 +54,7 @@ export default defineFontProvider('googleicons', async (providerOptions: Googlei
 
       // Legacy Material Icons
       if (family.includes('Icons')) {
-        css += await ctx.fetch(`https://fonts.googleapis.com/icon?family=${family}`, {
+        css += await fetchAPI(ctx, `https://fonts.googleapis.com/icon?family=${family}`, {
           headers: { 'user-agent': userAgent },
         }).then(res => res.text())
       }
@@ -65,7 +64,7 @@ export default defineFontProvider('googleicons', async (providerOptions: Googlei
         if (iconNames) {
           url += `&icon_names=${iconNames}`
         }
-        css += await ctx.fetch(url, {
+        css += await fetchAPI(ctx, url, {
           headers: { 'user-agent': userAgent },
         }).then(res => res.text())
       }

--- a/src/providers/npm.ts
+++ b/src/providers/npm.ts
@@ -5,6 +5,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 import { hash } from 'ohash'
 
 import { extractFontFaceData } from '../css/parse'
+import { fetchAPI } from '../internal'
 import { cleanFontFaces, defineFontProvider, filterKnownStyles } from '../utils'
 
 export interface NpmProviderOptions {
@@ -456,7 +457,7 @@ export default defineFontProvider('npm', (providerOptions: NpmProviderOptions, c
   }
 
   async function resolveFromCdn(pkgName: string, pkgVersion: string, cssFiles: string[], family: string, formats: ResolveFontOptions['formats']): Promise<FontFaceData[] | null> {
-    const stylesheets = await Promise.all(cssFiles.map(cssFile => ctx.fetch(`${cdn}/${pkgName}@${pkgVersion}/${cssFile}`).then(res => res.text()).catch(() => null)))
+    const stylesheets = await Promise.all(cssFiles.map(cssFile => fetchAPI(ctx, `${cdn}/${pkgName}@${pkgVersion}/${cssFile}`).then(res => res.text()).catch(() => null)))
 
     const fontFaces: FontFaceData[] = []
     for (const css of stylesheets) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,11 +10,6 @@ export interface ProviderContext {
     }
     setItem: (key: string, value: unknown) => Awaitable<void>
   }
-  /**
-   * Requests a provider API, retrying transient failures. Requests are routed through the
-   * `apiBase` proxy if one is configured, so providers should always request the upstream URL.
-   */
-  fetch: (url: string, init?: RequestInit) => Promise<Response>
 }
 
 export type FontStyles = 'normal' | 'italic' | 'oblique'

--- a/src/unifont.ts
+++ b/src/unifont.ts
@@ -1,8 +1,10 @@
 import type { Storage } from './cache'
-import type { FontProperties, InitializedProvider, Provider, ProviderContext, ResolveFontOptions, ResolveFontResult } from './types'
+import type { InternalProviderContext } from './internal'
+import type { FontProperties, InitializedProvider, Provider, ResolveFontOptions, ResolveFontResult } from './types'
 import { createAPIFetch } from './api-base'
 import { createAsyncStorage, memoryStorage } from './cache'
 import { installProxyDispatcher } from './env-proxy'
+import { API_FETCH } from './internal'
 
 export interface UnifontOptions {
   storage?: Storage
@@ -61,7 +63,7 @@ export async function createUnifont<T extends [Provider, ...Provider[]]>(provide
   const stack: Record<string, InitializedProvider> = {}
 
   const storage = unifontOptions?.storage ?? memoryStorage()
-  const fetch = createAPIFetch(unifontOptions?.apiBase)
+  const apiFetch = createAPIFetch(unifontOptions?.apiBase)
 
   // preserve provider order
   for (const provider of providers) {
@@ -71,11 +73,11 @@ export async function createUnifont<T extends [Provider, ...Provider[]]>(provide
 
   // initialize all providers in parallel
   await Promise.all(providers.map(async (provider) => {
-    const context: ProviderContext = {
+    const context: InternalProviderContext = {
       storage: createAsyncStorage(storage, {
         cachedBy: [provider._name, provider._options],
       }),
-      fetch,
+      [API_FETCH]: apiFetch,
     }
     try {
       const initializedProvider = await provider(context)


### PR DESCRIPTION
Removes `fetch` from `ProviderContext` and keeps it as an internal concern. It is an implementation detail of built-in providers.

When working on https://github.com/withastro/astro/pull/17830 I found this new thing which would leak in Astro. I could workaround it in Astro but I figured it'd be better to fix in unifont directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that custom providers use the browser’s standard network requests.
  * Custom provider APIs must support CORS or be accessed through a proxy in browser-based applications.
  * Clarified that API base URL rewriting applies only to built-in providers.
* **Improvements**
  * Standardized network requests across built-in font and icon providers while preserving existing retrieval behavior.
  * Cached storage behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->