### PR TITLE
feat: allow providers to report font metrics

### DIFF
--- a/docs/content/docs/9.reference.md
+++ b/docs/content/docs/9.reference.md
@@ -102,11 +102,30 @@ interface FontFaceData {
   unicodeRange?: string[]
   featureSettings?: string
   variationSettings?: string
+  metrics?: FontMetrics
   meta?: { priority?: number, subset?: string, init?: RequestInit }
 }
 ```
 
 A `src` entry with `name` is a local font, one with `url` is remote. `meta.subset` is the provider's own name for the range. `meta.init` holds a `RequestInit` for the few providers whose files need headers.
+
+## `FontMetrics`
+
+```ts
+interface FontMetrics {
+  unitsPerEm: number
+  ascent?: number
+  descent?: number
+  lineGap?: number
+  capHeight?: number
+  xHeight?: number
+  xWidthAvg?: number
+}
+```
+
+Values are in font units, using the same vocabulary as [`@capsizecss/metrics`](https://github.com/seek-oss/capsize), so they can be used to generate fallback metric overrides (`size-adjust`, `ascent-override`, ...) without downloading and parsing the font file.
+
+Only providers that publish metrics in their API responses report them, and they may report only some of the fields. `fontshare` is currently the only one. Metrics are attached per font face by `resolveFont()`, and the default face's metrics are also returned from `getFontProperties()`.
 
 ## `defineFontProvider()`
 

--- a/docs/content/docs/9.reference.md
+++ b/docs/content/docs/9.reference.md
@@ -125,8 +125,6 @@ interface FontMetrics {
 
 Values are in font units, using the same vocabulary as [`@capsizecss/metrics`](https://github.com/seek-oss/capsize), so they can be used to generate fallback metric overrides (`size-adjust`, `ascent-override`, ...) without downloading and parsing the font file.
 
-Only providers that publish metrics in their API responses report them, and they may report only some of the fields. `fontshare` is currently the only one. Metrics are attached per font face by `resolveFont()`, and the default face's metrics are also returned from `getFontProperties()`.
-
 ## `defineFontProvider()`
 
 ```ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export type { AdobeProviderOptions } from './providers/adobe'
 export type { GoogleFamilyOptions, GoogleProviderOptions } from './providers/google'
 export type { GoogleiconsFamilyOptions, GoogleiconsProviderOptions } from './providers/googleicons'
 export type { NpmFamilyOptions, NpmProviderOptions } from './providers/npm'
-export type { FontFaceData, FontFaceMeta, FontProperties, FontStyles, InitializedProvider, LocalFontSource, Provider, ProviderContext, ProviderDefinition, ProviderFactory, RemoteFontSource, ResolveFontOptions, ResolveFontResult } from './types'
+export type { FontFaceData, FontFaceMeta, FontMetrics, FontProperties, FontStyles, InitializedProvider, LocalFontSource, Provider, ProviderContext, ProviderDefinition, ProviderFactory, RemoteFontSource, ResolveFontOptions, ResolveFontResult } from './types'
 export type { Unifont, UnifontOptions } from './unifont'
 
 export { createUnifont, defaultResolveOptions } from './unifont'

--- a/src/providers/fontshare.ts
+++ b/src/providers/fontshare.ts
@@ -1,10 +1,34 @@
-import type { FontStyles, ResolveFontOptions } from '../types'
+import type { FontMetrics, FontStyles, ResolveFontOptions } from '../types'
 
 import { hash } from 'ohash'
 import { extractFontFaceData } from '../css/parse'
 import { cleanFontFaces, defineFontProvider, prepareWeights } from '../utils'
 
 const BASE_URL = 'https://api.fontshare.com/v2'
+
+// every family fontshare serves is drawn on a 1000-unit em, and its API reports metrics in
+// font units without saying so
+const UNITS_PER_EM = 1000
+
+function getMetrics(style: FontshareFontStyle): FontMetrics | undefined {
+  const properties = style.properties
+  if (!properties) {
+    return
+  }
+  const metrics: FontMetrics = { unitsPerEm: UNITS_PER_EM }
+  // `y_min`/`y_max` are glyph bounds rather than vertical metrics, and `descending_leading` does
+  // not match the font's descender, so the descender is not reported
+  if (properties.ascending_leading != null) {
+    metrics.ascent = properties.ascending_leading
+  }
+  if (properties.cap_height != null) {
+    metrics.capHeight = properties.cap_height
+  }
+  if (properties.x_height != null) {
+    metrics.xHeight = properties.x_height
+  }
+  return metrics
+}
 
 function getFallbacks(category: string): string[] | undefined {
   if (category.includes('Serif'))
@@ -101,7 +125,22 @@ export default defineFontProvider('fontshare', async (_options, ctx) => {
       }
     }
 
-    return cleanFontFaces(fontFaces, options.formats)
+    const faces = cleanFontFaces(fontFaces, options.formats)
+
+    for (const face of faces) {
+      const isItalic = face.style === 'italic'
+      const isVariable = Array.isArray(face.weight)
+      const style = font.styles.find(style => !!style.is_italic === isItalic
+        && (isVariable
+          ? style.is_variable
+          : !style.is_variable && String(style.weight.weight) === String(face.weight)))
+      const metrics = style && getMetrics(style)
+      if (metrics) {
+        face.metrics = metrics
+      }
+    }
+
+    return faces
   }
 
   return {
@@ -128,10 +167,13 @@ export default defineFontProvider('fontshare', async (_options, ctx) => {
           weights.add(style.weight.weight.toString())
         }
       }
+      const metrics = getMetrics(font.styles.find(style => style.default) ?? font.styles[0]!)
+
       return {
         formats: ['woff2', 'woff', 'ttf'],
         styles: [...styles],
         weights: [...weights],
+        ...(metrics ? { metrics } : {}),
       }
     },
     async resolveFont(fontFamily, defaults) {
@@ -152,34 +194,36 @@ export default defineFontProvider('fontshare', async (_options, ctx) => {
 
 /** internal */
 
+interface FontshareFontStyle {
+  default: boolean
+  file: string
+  id: string
+  is_italic: boolean
+  is_variable: boolean
+  properties: {
+    ascending_leading: number
+    body_height: null
+    cap_height: number
+    descending_leading: number
+    max_char_width: number
+    x_height: number
+    y_max: number
+    y_min: number
+  }
+  weight: {
+    label: string
+    name: string
+    native_name: null
+    number: number
+    weight: number
+  }
+}
+
 interface FontshareFontMeta {
   slug: string
   name: string
   category: string
-  styles: Array<{
-    default: boolean
-    file: string
-    id: string
-    is_italic: boolean
-    is_variable: boolean
-    properties: {
-      ascending_leading: number
-      body_height: null
-      cap_height: number
-      descending_leading: number
-      max_char_width: number
-      x_height: number
-      y_max: number
-      y_min: number
-    }
-    weight: {
-      label: string
-      name: string
-      native_name: null
-      number: number
-      weight: number
-    }
-  }>
+  styles: FontshareFontStyle[]
   axes: Array<{
     name: string
     property: 'wght' | 'ital' | 'opsz'

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,28 @@ export interface FontFaceMeta {
   init?: RequestInit
 }
 
+/**
+ * Font metrics in font units, using the same vocabulary as `@capsizecss/metrics`, from which
+ * fallback metric overrides (`size-adjust`, `ascent-override`, ...) can be calculated without
+ * downloading and parsing the font file.
+ */
+export interface FontMetrics {
+  /** The number of font units per em square. */
+  unitsPerEm: number
+  /** The ascender, in font units. */
+  ascent?: number
+  /** The descender, in font units. Usually negative. */
+  descent?: number
+  /** The line gap, in font units. */
+  lineGap?: number
+  /** The height of capital letters, in font units. */
+  capHeight?: number
+  /** The height of lowercase letters, in font units. */
+  xHeight?: number
+  /** The average width of a lowercase character, in font units. */
+  xWidthAvg?: number
+}
+
 // TODO: name
 export interface FontFaceData {
   src: Array<LocalFontSource | RemoteFontSource>
@@ -76,6 +98,11 @@ export interface FontFaceData {
   featureSettings?: string
   /** Allows low-level control over OpenType or TrueType font variations, by specifying the four letter axis names of the features to vary, along with their variation values. */
   variationSettings?: string
+  /**
+   * Metrics reported by the provider for this font face, if it knows them.
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/size-adjust
+   */
+  metrics?: FontMetrics
   /** Metadata for the font face used by unifont */
   meta?: FontFaceMeta
 }
@@ -107,6 +134,11 @@ export interface FontProperties {
    * per-family availability, so some formats may not exist for every family.
    */
   formats?: FontFormat[]
+  /**
+   * Metrics for the family's default font face, if the provider knows them. Individual
+   * faces may report different metrics from `resolveFont`.
+   */
+  metrics?: FontMetrics
 }
 
 export interface InitializedProvider<

--- a/test/providers/fontshare.test.ts
+++ b/test/providers/fontshare.test.ts
@@ -16,6 +16,12 @@ describe('fontshare', () => {
       [
         {
           "display": "swap",
+          "metrics": {
+            "ascent": 1010,
+            "capHeight": 716,
+            "unitsPerEm": 1000,
+            "xHeight": 484,
+          },
           "src": [
             {
               "format": "woff2",
@@ -38,6 +44,12 @@ describe('fontshare', () => {
       [
         {
           "display": "swap",
+          "metrics": {
+            "ascent": 1000,
+            "capHeight": 727,
+            "unitsPerEm": 1000,
+            "xHeight": 525,
+          },
           "src": [
             {
               "format": "woff2",
@@ -82,6 +94,88 @@ describe('fontshare', () => {
     expect(result?.weights).toEqual(expect.arrayContaining(['400', '300 900']))
 
     expect(await unifont.getFontProperties('XXX')).toEqual(undefined)
+  })
+
+  describe('metrics', () => {
+    it('reports metrics per font face', async () => {
+      const unifont = await createUnifont([providers.fontshare()])
+      const { fonts } = await unifont.resolveFont('Satoshi', { weights: ['300', '900'], styles: ['normal'] })
+      expect(fonts.map(font => font.metrics)).toMatchInlineSnapshot(`
+        [
+          {
+            "ascent": 1010,
+            "capHeight": 710,
+            "unitsPerEm": 1000,
+            "xHeight": 480,
+          },
+          {
+            "ascent": 1010,
+            "capHeight": 740,
+            "unitsPerEm": 1000,
+            "xHeight": 500,
+          },
+        ]
+      `)
+    })
+
+    it('reports metrics for variable font faces', async () => {
+      const unifont = await createUnifont([providers.fontshare()])
+      const { fonts } = await unifont.resolveFont('Satoshi', { weights: ['300 900'], styles: ['normal'] })
+      const variable = fonts.find(font => Array.isArray(font.weight))
+      expect(variable?.metrics?.unitsPerEm).toBe(1000)
+      expect(variable?.metrics?.ascent).toBeGreaterThan(0)
+    })
+
+    it('reports metrics for the default style from getFontProperties', async () => {
+      const unifont = await createUnifont([providers.fontshare()])
+      const properties = await unifont.getFontProperties('Satoshi')
+      expect(properties?.metrics).toMatchInlineSnapshot(`
+        {
+          "ascent": 1010,
+          "capHeight": 740,
+          "unitsPerEm": 1000,
+          "xHeight": 500,
+        }
+      `)
+    })
+
+    it.each([
+      ['no properties', undefined, undefined],
+      ['empty properties', {}, { unitsPerEm: 1000 }],
+    ])('handles a style with %s', async (_name, properties, expected) => {
+      const restore = mockFetchReturn(/api\.fontshare\.com/, (request) => {
+        const url = String(request)
+        if (url.includes('/fonts?')) {
+          return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({
+            has_more: false,
+            fonts: [{
+              name: 'No Metrics',
+              slug: 'no-metrics',
+              category: 'Sans Serif',
+              axes: [],
+              styles: [{ default: true, is_italic: false, is_variable: false, properties, weight: { number: 400, weight: 400 } }],
+            }],
+          }) })
+        }
+        return Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve(`@font-face {
+          font-family: 'No Metrics';
+          font-style: normal;
+          font-weight: 400;
+          src: url(https://cdn.fontshare.com/400.woff2) format('woff2');
+        }`) })
+      })
+
+      try {
+        const unifont = await createUnifont([providers.fontshare()])
+        const { fonts } = await unifont.resolveFont('No Metrics', { weights: ['400'], styles: ['normal'], formats: ['woff2'] })
+        expect(fonts.length).toBe(1)
+        expect(fonts[0]!.metrics).toEqual(expected)
+        expect((await unifont.getFontProperties('No Metrics'))?.metrics).toEqual(expected)
+      }
+      finally {
+        restore()
+      }
+    })
   })
 
   it('omits a variable weight range when the family has no wght axis', async () => {


### PR DESCRIPTION
resolves https://github.com/nuxt/fonts/issues/9

`fontaine`/`fontless` need font metrics to emit fallback `@font-face` rules with metric overrides. today they either look the family up in `@capsizecss/metrics` or download the font file at build time.

but some providers already publish those numbers in the responses we're fetching anyway, so we may as well pass them through.

this adds an optional `FontMetrics` on `FontFaceData`, using the capsize vocabulary:

```ts
export interface FontMetrics {
  unitsPerEm: number
  ascent?: number
  descent?: number
  lineGap?: number
  capHeight?: number
  xHeight?: number
  xWidthAvg?: number
}
```

on the provider side, only `fontshare` publishes anything usable:

| provider | metrics in the api |
| --- | --- |
| `fontshare` | `ascending_leading`, `cap_height`, `x_height` per style |
| `google` | only a per-weight `lineHeight` ratio, no upem/ascent/descent |
| `bunny` | none |
| `fontsource` | none |
| `adobe` | none |
| `npm` | n/a, we parse the package's own css |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Font data now supports optional metrics, including units per em, ascent, descent, line gap, cap height, x-height, and average lowercase width.
  * Font metrics are available for resolved Fontshare fonts and font property results, including static and variable faces.
  * The new `FontMetrics` type is publicly available.

* **Documentation**
  * Added reference documentation describing font metrics, their units, and supported fields.

* **Tests**
  * Added coverage for metrics across font styles, variable fonts, and missing or empty metric data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->